### PR TITLE
Diego fix assethub panics

### DIFF
--- a/crates/anvil-polkadot/src/api_server/server.rs
+++ b/crates/anvil-polkadot/src/api_server/server.rs
@@ -1967,7 +1967,6 @@ async fn create_revive_rpc_client(
             block_provider.clone(),
             task_spawn_handle.clone(),
             keep_latest_n_blocks,
-            in_fork_mode,
         )
         .await
         {
@@ -1994,7 +1993,6 @@ async fn create_revive_rpc_client(
         block_provider,
         task_spawn_handle,
         keep_latest_n_blocks,
-        in_fork_mode,
     )
     .await
     .map(Some)
@@ -2007,7 +2005,6 @@ async fn create_revive_client_impl(
     block_provider: SubxtBlockInfoProvider,
     task_spawn_handle: SpawnTaskHandle,
     keep_latest_n_blocks: Option<usize>,
-    in_fork_mode: bool,
 ) -> Result<EthRpcClient> {
     let pool = SqlitePoolOptions::new()
         .max_connections(1)
@@ -2041,28 +2038,18 @@ async fn create_revive_client_impl(
 
     // Capacity is chosen using random.org
     eth_rpc_client.set_block_notifier(Some(tokio::sync::broadcast::channel::<H256>(50).0));
-
-    // In fork mode, skip block subscription to avoid ReceiptDataNotFound errors
-    // when processing blocks from the remote chain. In fork mode, we create our own
-    // local blocks using manual-seal, and don't need to subscribe to remote blocks.
-    if !in_fork_mode {
-        let eth_rpc_client_clone = eth_rpc_client.clone();
-        task_spawn_handle.spawn("block-subscription", "None", async move {
-            let eth_rpc_client = eth_rpc_client_clone;
-            let best_future =
-                eth_rpc_client.subscribe_and_cache_new_blocks(SubscriptionType::BestBlocks);
-            let finalized_future =
-                eth_rpc_client.subscribe_and_cache_new_blocks(SubscriptionType::FinalizedBlocks);
-            let res = tokio::try_join!(best_future, finalized_future).map(|_| ());
-            if let Err(err) = res {
-                panic!("Block subscription task failed: {err:?}")
-            }
-        });
-    } else {
-        tracing::info!(
-            "Skipping block subscription in fork mode - blocks will be created locally via manual-seal"
-        );
-    }
+    let eth_rpc_client_clone = eth_rpc_client.clone();
+    task_spawn_handle.spawn("block-subscription", "None", async move {
+        let eth_rpc_client = eth_rpc_client_clone;
+        let best_future =
+            eth_rpc_client.subscribe_and_cache_new_blocks(SubscriptionType::BestBlocks);
+        let finalized_future =
+            eth_rpc_client.subscribe_and_cache_new_blocks(SubscriptionType::FinalizedBlocks);
+        let res = tokio::try_join!(best_future, finalized_future).map(|_| ());
+        if let Err(err) = res {
+            panic!("Block subscription task failed: {err:?}")
+        }
+    });
 
     Ok(eth_rpc_client)
 }

--- a/crates/anvil-polkadot/src/api_server/server.rs
+++ b/crates/anvil-polkadot/src/api_server/server.rs
@@ -73,7 +73,7 @@ use polkadot_sdk::{
     },
     parachains_common::{AccountId, Hash, Nonce},
     polkadot_sdk_frame::runtime::types_common::OpaqueBlock,
-    sc_client_api::HeaderBackend,
+    sc_client_api::{Backend as BackendT, HeaderBackend},
     sc_service::{InPoolTransaction, SpawnTaskHandle, TransactionPool},
     sp_api::{Metadata as _, ProvideRuntimeApi},
     sp_blockchain::Info,
@@ -137,6 +137,10 @@ impl ApiServer {
         let api = create_online_client(&substrate_service, rpc_client.clone()).await?;
         let rpc = LegacyRpcMethods::<SrcChainConfig>::new(rpc_client.clone());
         let block_provider = SubxtBlockInfoProvider::new(api.clone(), rpc.clone()).await?;
+
+        // Check if we're in fork mode by checking if the backend has an RPC client
+        let is_fork_mode = substrate_service.backend.rpc().is_some();
+
         let eth_rpc_client = create_revive_rpc_client(
             api.clone(),
             rpc_client.clone(),
@@ -144,6 +148,7 @@ impl ApiServer {
             block_provider.clone(),
             substrate_service.spawn_handle.clone(),
             revive_rpc_block_limit,
+            is_fork_mode,
         )
         .await?;
 
@@ -1868,21 +1873,15 @@ async fn create_online_client(
     substrate_service: &Service,
     rpc_client: RpcClient,
 ) -> Result<OnlineClient<SrcChainConfig>> {
-    let genesis_block_number = substrate_service.genesis_block_number.try_into().map_err(|_| {
-        Error::InternalError(format!(
-            "Genesis block number {} is too large for u32 (max: {})",
-            substrate_service.genesis_block_number,
-            u32::MAX
-        ))
-    })?;
+    // Get genesis hash directly from blockchain info instead of querying by number
+    // This works correctly for both normal and fork modes
+    let genesis_hash = substrate_service.backend.blockchain().info().genesis_hash;
 
-    let Some(genesis_hash) = substrate_service.client.hash(genesis_block_number).ok().flatten()
-    else {
-        return Err(Error::InternalError(format!(
-            "Genesis hash not found for genesis block number {}",
-            substrate_service.genesis_block_number
-        )));
-    };
+    if genesis_hash == Default::default() {
+        return Err(Error::InternalError(
+            "Genesis hash not initialized in blockchain storage".to_string(),
+        ));
+    }
 
     let Ok(runtime_version) = substrate_service.client.runtime_version_at(genesis_hash) else {
         return Err(Error::InternalError(
@@ -1895,11 +1894,17 @@ async fn create_online_client(
         transaction_version: runtime_version.transaction_version,
     };
 
-    let Ok(supported_metadata_versions) =
-        substrate_service.client.runtime_api().metadata_versions(genesis_hash)
-    else {
-        return Err(Error::InternalError("Unable to fetch metadata versions".to_string()));
-    };
+    // In fork mode, genesis block may not have runtime code available.
+    // Try genesis first, then fall back to best block if that fails.
+    let supported_metadata_versions = substrate_service
+        .client
+        .runtime_api()
+        .metadata_versions(genesis_hash)
+        .or_else(|_| {
+            let best_hash = substrate_service.backend.blockchain().info().best_hash;
+            substrate_service.client.runtime_api().metadata_versions(best_hash)
+        })
+        .map_err(|e| Error::InternalError(format!("Unable to fetch metadata versions: {e}")))?;
 
     let Some(latest_metadata_version) = supported_metadata_versions.into_iter().max() else {
         return Err(Error::InternalError("No stable metadata versions supported".to_string()));
@@ -1938,6 +1943,7 @@ async fn create_revive_rpc_client(
     block_provider: SubxtBlockInfoProvider,
     task_spawn_handle: SpawnTaskHandle,
     keep_latest_n_blocks: Option<usize>,
+    is_fork_mode: bool,
 ) -> Result<EthRpcClient> {
     let pool = SqlitePoolOptions::new()
         .max_connections(1)
@@ -1970,18 +1976,26 @@ async fn create_revive_rpc_client(
 
     // Capacity is chosen using random.org
     eth_rpc_client.set_block_notifier(Some(tokio::sync::broadcast::channel::<H256>(50).0));
-    let eth_rpc_client_clone = eth_rpc_client.clone();
-    task_spawn_handle.spawn("block-subscription", "None", async move {
-        let eth_rpc_client = eth_rpc_client_clone;
-        let best_future =
-            eth_rpc_client.subscribe_and_cache_new_blocks(SubscriptionType::BestBlocks);
-        let finalized_future =
-            eth_rpc_client.subscribe_and_cache_new_blocks(SubscriptionType::FinalizedBlocks);
-        let res = tokio::try_join!(best_future, finalized_future).map(|_| ());
-        if let Err(err) = res {
-            panic!("Block subscription task failed: {err:?}")
-        }
-    });
+
+    // In fork mode, we don't subscribe to new blocks from the remote chain because:
+    // 1. We're working with a snapshot at the fork checkpoint
+    // 2. Subscribing to blocks beyond the checkpoint causes ReceiptDataNotFound errors
+    // 3. New blocks after the fork are produced locally, not fetched from remote
+    if !is_fork_mode {
+        let eth_rpc_client_clone = eth_rpc_client.clone();
+        task_spawn_handle.spawn("block-subscription", "None", async move {
+            let eth_rpc_client = eth_rpc_client_clone;
+            let best_future =
+                eth_rpc_client.subscribe_and_cache_new_blocks(SubscriptionType::BestBlocks);
+            let finalized_future =
+                eth_rpc_client.subscribe_and_cache_new_blocks(SubscriptionType::FinalizedBlocks);
+            let res = tokio::try_join!(best_future, finalized_future).map(|_| ());
+            if let Err(err) = res {
+                // Log the error instead of panicking - this is expected during shutdown
+                warn!("Block subscription task ended: {err:?}");
+            }
+        });
+    }
 
     Ok(eth_rpc_client)
 }

--- a/crates/anvil-polkadot/src/api_server/server.rs
+++ b/crates/anvil-polkadot/src/api_server/server.rs
@@ -63,7 +63,6 @@ use pallet_revive_eth_rpc::{
     },
 };
 use polkadot_sdk::{
-    cumulus_primitives_core::GetParachainInfo,
     pallet_revive::{
         ReviveApi,
         evm::{
@@ -113,6 +112,13 @@ pub struct ApiServer {
     instance_id: B256,
     /// Tracks all active filters
     filters: Filters,
+    hardcoded_chain_id: u64,
+}
+
+/// Fetch the chain ID from the substrate chain.
+async fn chain_id(api: &OnlineClient<SrcChainConfig>) -> Result<u64> {
+    let query = subxt_client::constants().revive().chain_id();
+    api.constants().at(&query).map_err(|err| err.into())
 }
 
 impl ApiServer {
@@ -141,6 +147,16 @@ impl ApiServer {
         )
         .await?;
 
+        let backend = BackendWithOverlay::new(
+            substrate_service.backend.clone(),
+            substrate_service.storage_overrides.clone(),
+        );
+
+        // When forking we need to use the chain ID of the forked network, but for non-forking we do
+        // not want to use this as we allow for the chain_id to be customized. So we will
+        // not write this to the backend, but cache it to use if we are forking.
+        let chain_id = chain_id(&api).await?;
+
         let filters_clone = filters.clone();
         substrate_service.spawn_handle.spawn("filter-eviction-task", "None", async move {
             eviction_task(filters_clone).await;
@@ -149,10 +165,7 @@ impl ApiServer {
             block_provider,
             req_receiver,
             logging_manager,
-            backend: BackendWithOverlay::new(
-                substrate_service.backend.clone(),
-                substrate_service.storage_overrides.clone(),
-            ),
+            backend,
             client: substrate_service.client.clone(),
             mining_engine: substrate_service.mining_engine.clone(),
             eth_rpc_client,
@@ -162,6 +175,7 @@ impl ApiServer {
             wallet: DevSigner::new(signers)?,
             instance_id: B256::random(),
             filters,
+            hardcoded_chain_id: chain_id,
         })
     }
 
@@ -618,25 +632,17 @@ impl ApiServer {
         Ok(())
     }
 
-    fn chain_id(&self, at: Hash) -> u64 {
-        // .expect("Chain ID is populated on genesis");
+    fn chain_id_from_metadata(&self, at: Hash) -> u64 {
         let id_res = self.backend.read_chain_id(at);
 
-        let para_id = match id_res {
+        let id = match id_res {
             Ok(id) => id,
-            Err(_) => {
-                let id = self
-                    .client
-                    .runtime_api()
-                    .parachain_id(at)
-                    .expect("retrieving chain id from runtime");
-
-                let id_u64: u32 = id.into();
-                id_u64 as u64
-            }
+            // If chain_id is not found in the backend, we are forking so use the cached chain_id
+            // from the forked network
+            Err(_) => self.hardcoded_chain_id,
         };
 
-        para_id
+        id
     }
 
     // Eth RPCs
@@ -644,14 +650,14 @@ impl ApiServer {
         node_info!("eth_chainId");
         let latest_block = self.latest_block();
 
-        Ok(U256::from(self.chain_id(latest_block)).to::<U64>())
+        Ok(U256::from(self.chain_id_from_metadata(latest_block)).to::<U64>())
     }
 
     fn network_id(&self) -> Result<u64> {
         node_info!("eth_networkId");
         let latest_block = self.latest_block();
 
-        Ok(self.chain_id(latest_block))
+        Ok(self.chain_id_from_metadata(latest_block))
     }
 
     fn net_listening(&self) -> Result<bool> {
@@ -847,8 +853,9 @@ impl ApiServer {
 
         if transaction.chain_id.is_none() {
             println!("chain id is none");
-            transaction.chain_id =
-                Some(sp_core::U256::from_big_endian(&self.chain_id(latest_block).to_be_bytes()));
+            transaction.chain_id = Some(sp_core::U256::from_big_endian(
+                &self.chain_id_from_metadata(latest_block).to_be_bytes(),
+            ));
         }
 
         let tx = transaction
@@ -985,7 +992,7 @@ impl ApiServer {
             transaction_order: "fifo".to_string(),
             environment: NodeEnvironment {
                 base_fee,
-                chain_id: self.chain_id(best_hash),
+                chain_id: self.chain_id_from_metadata(best_hash),
                 gas_limit,
                 gas_price: base_fee,
             },
@@ -1008,7 +1015,7 @@ impl ApiServer {
 
         Ok(AnvilMetadata {
             client_version: CLIENT_VERSION.to_string(),
-            chain_id: self.chain_id(best_hash),
+            chain_id: self.chain_id_from_metadata(best_hash),
             latest_block_hash: B256::from_slice(best_hash.as_ref()),
             latest_block_number,
             instance_id: self.instance_id,
@@ -1861,20 +1868,28 @@ async fn create_online_client(
     substrate_service: &Service,
     rpc_client: RpcClient,
 ) -> Result<OnlineClient<SrcChainConfig>> {
-    let genesis_block_number = substrate_service.genesis_block_number.try_into().map_err(|_| {
-        Error::InternalError(format!(
-            "Genesis block number {} is too large for u32 (max: {})",
-            substrate_service.genesis_block_number,
-            u32::MAX
-        ))
-    })?;
+    // In fork mode, use the checkpoint hash directly to avoid lazy loading issues
+    // In normal mode, get the hash from the genesis block number
+    let genesis_hash = if let Some(checkpoint_hash) = substrate_service.checkpoint_hash {
+        // Fork mode: use the actual checkpoint block hash
+        checkpoint_hash
+    } else {
+        // Normal mode: get hash from genesis block number
+        let genesis_block_number = substrate_service.genesis_block_number.try_into().map_err(|_| {
+            Error::InternalError(format!(
+                "Genesis block number {} is too large for u32 (max: {})",
+                substrate_service.genesis_block_number,
+                u32::MAX
+            ))
+        })?;
 
-    let Some(genesis_hash) = substrate_service.client.hash(genesis_block_number).ok().flatten()
-    else {
-        return Err(Error::InternalError(format!(
-            "Genesis hash not found for genesis block number {}",
-            substrate_service.genesis_block_number
-        )));
+        let Some(hash) = substrate_service.client.hash(genesis_block_number).ok().flatten() else {
+            return Err(Error::InternalError(format!(
+                "Genesis hash not found for genesis block number {}",
+                substrate_service.genesis_block_number
+            )));
+        };
+        hash
     };
 
     let Ok(runtime_version) = substrate_service.client.runtime_version_at(genesis_hash) else {
@@ -1888,59 +1903,30 @@ async fn create_online_client(
         transaction_version: runtime_version.transaction_version,
     };
 
-    // In fork mode, use RPC to fetch metadata directly to avoid lazy loading issues
-    // In normal mode, use the local runtime API
-    let subxt_metadata = if let Some(fork_url) = &substrate_service.fork_url {
-        // Fork mode: Create a temporary RPC client pointing to the remote fork URL
-        // to fetch metadata directly, avoiding lazy loading backend issues
-
-        // Convert HTTP(S) URLs to WebSocket URLs (ws/wss) as required by RpcClient
-        let ws_url = fork_url.replace("https://", "wss://").replace("http://", "ws://");
-
-        let remote_client = subxt::backend::rpc::RpcClient::from_url(&ws_url)
-            .await
-            .map_err(|err| {
-                Error::InternalError(format!(
-                    "Failed to connect to fork URL for metadata fetch: {err}"
-                ))
-            })?;
-
-        OnlineClient::<SrcChainConfig>::from_rpc_client(remote_client)
-            .await
-            .map_err(|err| {
-                Error::InternalError(format!(
-                    "Failed to create temporary client for metadata fetch in fork mode: {err}"
-                ))
-            })?
-            .metadata()
-            .clone()
-    } else {
-        // Normal mode: use local runtime API
-        let Ok(supported_metadata_versions) =
-            substrate_service.client.runtime_api().metadata_versions(genesis_hash)
-        else {
-            return Err(Error::InternalError("Unable to fetch metadata versions".to_string()));
-        };
-
-        let Some(latest_metadata_version) = supported_metadata_versions.into_iter().max() else {
-            return Err(Error::InternalError("No stable metadata versions supported".to_string()));
-        };
-
-        let opaque_metadata = substrate_service
-            .client
-            .runtime_api()
-            .metadata_at_version(genesis_hash, latest_metadata_version)
-            .map_err(|_| {
-                Error::InternalError("Failed to get runtime API for genesis hash".to_string())
-            })?
-            .ok_or_else(|| {
-                Error::InternalError(format!(
-                    "Metadata not found for version {latest_metadata_version} at genesis hash"
-                ))
-            })?;
-        SubxtMetadata::decode(&mut (*opaque_metadata).as_slice())
-            .map_err(|_| Error::InternalError("Unable to decode metadata".to_string()))?
+    let Ok(supported_metadata_versions) =
+        substrate_service.client.runtime_api().metadata_versions(genesis_hash)
+    else {
+        return Err(Error::InternalError("Unable to fetch metadata versions".to_string()));
     };
+
+    let Some(latest_metadata_version) = supported_metadata_versions.into_iter().max() else {
+        return Err(Error::InternalError("No stable metadata versions supported".to_string()));
+    };
+
+    let opaque_metadata = substrate_service
+        .client
+        .runtime_api()
+        .metadata_at_version(genesis_hash, latest_metadata_version)
+        .map_err(|_| {
+            Error::InternalError("Failed to get runtime API for genesis hash".to_string())
+        })?
+        .ok_or_else(|| {
+            Error::InternalError(format!(
+                "Metadata not found for version {latest_metadata_version} at genesis hash"
+            ))
+        })?;
+    let subxt_metadata = SubxtMetadata::decode(&mut (*opaque_metadata).as_slice())
+        .map_err(|_| Error::InternalError("Unable to decode metadata".to_string()))?;
 
     OnlineClient::<SrcChainConfig>::from_rpc_client_with(
         genesis_hash,

--- a/crates/anvil-polkadot/src/api_server/server.rs
+++ b/crates/anvil-polkadot/src/api_server/server.rs
@@ -1967,6 +1967,7 @@ async fn create_revive_rpc_client(
             block_provider.clone(),
             task_spawn_handle.clone(),
             keep_latest_n_blocks,
+            in_fork_mode,
         )
         .await
         {
@@ -1993,6 +1994,7 @@ async fn create_revive_rpc_client(
         block_provider,
         task_spawn_handle,
         keep_latest_n_blocks,
+        in_fork_mode,
     )
     .await
     .map(Some)
@@ -2005,6 +2007,7 @@ async fn create_revive_client_impl(
     block_provider: SubxtBlockInfoProvider,
     task_spawn_handle: SpawnTaskHandle,
     keep_latest_n_blocks: Option<usize>,
+    in_fork_mode: bool,
 ) -> Result<EthRpcClient> {
     let pool = SqlitePoolOptions::new()
         .max_connections(1)
@@ -2038,18 +2041,28 @@ async fn create_revive_client_impl(
 
     // Capacity is chosen using random.org
     eth_rpc_client.set_block_notifier(Some(tokio::sync::broadcast::channel::<H256>(50).0));
-    let eth_rpc_client_clone = eth_rpc_client.clone();
-    task_spawn_handle.spawn("block-subscription", "None", async move {
-        let eth_rpc_client = eth_rpc_client_clone;
-        let best_future =
-            eth_rpc_client.subscribe_and_cache_new_blocks(SubscriptionType::BestBlocks);
-        let finalized_future =
-            eth_rpc_client.subscribe_and_cache_new_blocks(SubscriptionType::FinalizedBlocks);
-        let res = tokio::try_join!(best_future, finalized_future).map(|_| ());
-        if let Err(err) = res {
-            panic!("Block subscription task failed: {err:?}")
-        }
-    });
+
+    // In fork mode, skip block subscription to avoid ReceiptDataNotFound errors
+    // when processing blocks from the remote chain. In fork mode, we create our own
+    // local blocks using manual-seal, and don't need to subscribe to remote blocks.
+    if !in_fork_mode {
+        let eth_rpc_client_clone = eth_rpc_client.clone();
+        task_spawn_handle.spawn("block-subscription", "None", async move {
+            let eth_rpc_client = eth_rpc_client_clone;
+            let best_future =
+                eth_rpc_client.subscribe_and_cache_new_blocks(SubscriptionType::BestBlocks);
+            let finalized_future =
+                eth_rpc_client.subscribe_and_cache_new_blocks(SubscriptionType::FinalizedBlocks);
+            let res = tokio::try_join!(best_future, finalized_future).map(|_| ());
+            if let Err(err) = res {
+                panic!("Block subscription task failed: {err:?}")
+            }
+        });
+    } else {
+        tracing::info!(
+            "Skipping block subscription in fork mode - blocks will be created locally via manual-seal"
+        );
+    }
 
     Ok(eth_rpc_client)
 }

--- a/crates/anvil-polkadot/src/api_server/server.rs
+++ b/crates/anvil-polkadot/src/api_server/server.rs
@@ -63,6 +63,7 @@ use pallet_revive_eth_rpc::{
     },
 };
 use polkadot_sdk::{
+    cumulus_primitives_core::GetParachainInfo,
     pallet_revive::{
         ReviveApi,
         evm::{
@@ -98,7 +99,7 @@ pub const CLIENT_VERSION: &str = concat!("anvil-polkadot/v", env!("CARGO_PKG_VER
 const TIMEOUT_DURATION: Duration = Duration::from_secs(30);
 
 pub struct ApiServer {
-    eth_rpc_client: Option<EthRpcClient>,
+    eth_rpc_client: EthRpcClient,
     req_receiver: mpsc::Receiver<ApiRequest>,
     backend: BackendWithOverlay,
     logging_manager: LoggingManager,
@@ -112,13 +113,6 @@ pub struct ApiServer {
     instance_id: B256,
     /// Tracks all active filters
     filters: Filters,
-    hardcoded_chain_id: u64,
-}
-
-/// Fetch the chain ID from the substrate chain.
-async fn chain_id(api: &OnlineClient<SrcChainConfig>) -> Result<u64> {
-    let query = subxt_client::constants().revive().chain_id();
-    api.constants().at(&query).map_err(|err| err.into())
 }
 
 impl ApiServer {
@@ -144,19 +138,8 @@ impl ApiServer {
             block_provider.clone(),
             substrate_service.spawn_handle.clone(),
             revive_rpc_block_limit,
-            substrate_service.fork_url.is_some(), // in_fork_mode
         )
         .await?;
-
-        let backend = BackendWithOverlay::new(
-            substrate_service.backend.clone(),
-            substrate_service.storage_overrides.clone(),
-        );
-
-        // When forking we need to use the chain ID of the forked network, but for non-forking we do
-        // not want to use this as we allow for the chain_id to be customized. So we will
-        // not write this to the backend, but cache it to use if we are forking.
-        let chain_id = chain_id(&api).await?;
 
         let filters_clone = filters.clone();
         substrate_service.spawn_handle.spawn("filter-eviction-task", "None", async move {
@@ -166,7 +149,10 @@ impl ApiServer {
             block_provider,
             req_receiver,
             logging_manager,
-            backend,
+            backend: BackendWithOverlay::new(
+                substrate_service.backend.clone(),
+                substrate_service.storage_overrides.clone(),
+            ),
             client: substrate_service.client.clone(),
             mining_engine: substrate_service.mining_engine.clone(),
             eth_rpc_client,
@@ -176,16 +162,6 @@ impl ApiServer {
             wallet: DevSigner::new(signers)?,
             instance_id: B256::random(),
             filters,
-            hardcoded_chain_id: chain_id,
-        })
-    }
-
-    /// Returns a reference to the eth_rpc_client, or an error if it's not available (fork mode without ReviveApi)
-    fn eth_rpc_client(&self) -> Result<&EthRpcClient> {
-        self.eth_rpc_client.as_ref().ok_or_else(|| {
-            Error::InternalError(
-                "EVM RPC functionality not available. This chain was forked without ReviveApi support.".to_string()
-            )
         })
     }
 
@@ -491,7 +467,7 @@ impl ApiServer {
         }
 
         // Subscribe to new best blocks.
-        let receiver = self.eth_rpc_client()?.block_notifier().map(|sender| sender.subscribe());
+        let receiver = self.eth_rpc_client.block_notifier().map(|sender| sender.subscribe());
 
         let awaited_hash = self
             .mining_engine
@@ -532,7 +508,7 @@ impl ApiServer {
         node_info!("evm_mine");
 
         // Subscribe to new best blocks.
-        let receiver = self.eth_rpc_client()?.block_notifier().map(|sender| sender.subscribe());
+        let receiver = self.eth_rpc_client.block_notifier().map(|sender| sender.subscribe());
         let awaited_hash = self.mining_engine.evm_mine(mine.and_then(|p| p.params)).await?;
         self.wait_for_hash(receiver, awaited_hash).await?;
         Ok("0x0".to_string())
@@ -545,7 +521,7 @@ impl ApiServer {
         node_info!("evm_mine_detailed");
 
         // Subscribe to new best blocks.
-        let receiver = self.eth_rpc_client()?.block_notifier().map(|sender| sender.subscribe());
+        let receiver = self.eth_rpc_client.block_notifier().map(|sender| sender.subscribe());
 
         let (mined_blocks, awaited_hash) =
             self.mining_engine.do_evm_mine(mine.and_then(|p| p.params)).await?;
@@ -642,17 +618,25 @@ impl ApiServer {
         Ok(())
     }
 
-    fn chain_id_from_metadata(&self, at: Hash) -> u64 {
+    fn chain_id(&self, at: Hash) -> u64 {
+        // .expect("Chain ID is populated on genesis");
         let id_res = self.backend.read_chain_id(at);
 
-        let id = match id_res {
+        let para_id = match id_res {
             Ok(id) => id,
-            // If chain_id is not found in the backend, we are forking so use the cached chain_id
-            // from the forked network
-            Err(_) => self.hardcoded_chain_id,
+            Err(_) => {
+                let id = self
+                    .client
+                    .runtime_api()
+                    .parachain_id(at)
+                    .expect("retrieving chain id from runtime");
+
+                let id_u64: u32 = id.into();
+                id_u64 as u64
+            }
         };
 
-        id
+        para_id
     }
 
     // Eth RPCs
@@ -660,14 +644,14 @@ impl ApiServer {
         node_info!("eth_chainId");
         let latest_block = self.latest_block();
 
-        Ok(U256::from(self.chain_id_from_metadata(latest_block)).to::<U64>())
+        Ok(U256::from(self.chain_id(latest_block)).to::<U64>())
     }
 
     fn network_id(&self) -> Result<u64> {
         node_info!("eth_networkId");
         let latest_block = self.latest_block();
 
-        Ok(self.chain_id_from_metadata(latest_block))
+        Ok(self.chain_id(latest_block))
     }
 
     fn net_listening(&self) -> Result<bool> {
@@ -682,14 +666,14 @@ impl ApiServer {
 
     async fn transaction_receipt(&self, tx_hash: B256) -> Result<Option<ReceiptInfo>> {
         node_info!("eth_getTransactionReceipt");
-        Ok(self.eth_rpc_client()?.receipt(&(tx_hash.0.into())).await)
+        Ok(self.eth_rpc_client.receipt(&(tx_hash.0.into())).await)
     }
 
     async fn get_balance(&self, addr: Address, block: Option<BlockId>) -> Result<U256> {
         node_info!("eth_getBalance");
         let hash = self.get_block_hash_for_tag(block).await?;
 
-        let runtime_api = self.eth_rpc_client()?.runtime_api(hash);
+        let runtime_api = self.eth_rpc_client.runtime_api(hash);
         let balance = runtime_api.balance(ReviveAddress::from(addr).inner()).await?;
         Ok(AlloyU256::from(balance).inner())
     }
@@ -702,7 +686,7 @@ impl ApiServer {
     ) -> Result<B256> {
         node_info!("eth_getStorageAt");
         let hash = self.get_block_hash_for_tag(block).await?;
-        let runtime_api = self.eth_rpc_client()?.runtime_api(hash);
+        let runtime_api = self.eth_rpc_client.runtime_api(hash);
         let bytes: B256 = match runtime_api
             .get_storage(ReviveAddress::from(addr).inner(), slot.to_be_bytes())
             .await
@@ -721,7 +705,7 @@ impl ApiServer {
 
         let hash = self.get_block_hash_for_tag(block).await?;
         let code = self
-            .eth_rpc_client()?
+            .eth_rpc_client
             .runtime_api(hash)
             .code(ReviveAddress::from(address).inner())
             .await?;
@@ -735,11 +719,11 @@ impl ApiServer {
     ) -> Result<Option<Block>> {
         node_info!("eth_getBlockByHash");
         let Some(block) =
-            self.eth_rpc_client()?.block_by_hash(&H256::from_slice(block_hash.as_slice())).await?
+            self.eth_rpc_client.block_by_hash(&H256::from_slice(block_hash.as_slice())).await?
         else {
             return Ok(None);
         };
-        let block = self.eth_rpc_client()?.evm_block(block, hydrated_transactions).await;
+        let block = self.eth_rpc_client.evm_block(block, hydrated_transactions).await;
         Ok(block)
     }
 
@@ -751,7 +735,7 @@ impl ApiServer {
         node_info!("eth_estimateGas");
 
         let hash = self.get_block_hash_for_tag(block).await?;
-        let runtime_api = self.eth_rpc_client()?.runtime_api(hash);
+        let runtime_api = self.eth_rpc_client.runtime_api(hash);
         let dry_run = runtime_api
             .dry_run(
                 convert_to_generic_transaction(request.into_inner()),
@@ -770,7 +754,7 @@ impl ApiServer {
 
         let hash = self.get_block_hash_for_tag(block).await?;
 
-        let runtime_api = self.eth_rpc_client()?.runtime_api(hash);
+        let runtime_api = self.eth_rpc_client.runtime_api(hash);
         let dry_run = runtime_api
             .dry_run(
                 convert_to_generic_transaction(request.into_inner()),
@@ -786,7 +770,7 @@ impl ApiServer {
 
         let hash = self.latest_block();
 
-        let runtime_api = self.eth_rpc_client()?.runtime_api(hash);
+        let runtime_api = self.eth_rpc_client.runtime_api(hash);
         runtime_api.gas_price().await.map_err(Error::from)
     }
 
@@ -797,7 +781,7 @@ impl ApiServer {
     ) -> Result<sp_core::U256> {
         node_info!("eth_getTransactionCount");
         let hash = self.get_block_hash_for_tag(block).await?;
-        let runtime_api = self.eth_rpc_client()?.runtime_api(hash);
+        let runtime_api = self.eth_rpc_client.runtime_api(hash);
         let nonce = runtime_api.nonce(address).await?;
         Ok(nonce)
     }
@@ -805,7 +789,7 @@ impl ApiServer {
     async fn send_raw_transaction(&self, transaction: Bytes) -> Result<H256> {
         let hash = H256(keccak_256(&transaction.0));
         let call = subxt_client::tx().revive().eth_transact(transaction.0);
-        self.eth_rpc_client()?.submit(call).await?;
+        self.eth_rpc_client.submit(call).await?;
         Ok(hash)
     }
 
@@ -813,7 +797,7 @@ impl ApiServer {
         node_info!("eth_sendRawTransactionSync");
         // Subscribe to new best blocks.
         let receiver = self
-            .eth_rpc_client()?
+            .eth_rpc_client
             .block_notifier()
             .ok_or_else(|| {
                 Error::InternalError("Invalid receiver. Unable to wait for receipt".to_string())
@@ -863,9 +847,8 @@ impl ApiServer {
 
         if transaction.chain_id.is_none() {
             println!("chain id is none");
-            transaction.chain_id = Some(sp_core::U256::from_big_endian(
-                &self.chain_id_from_metadata(latest_block).to_be_bytes(),
-            ));
+            transaction.chain_id =
+                Some(sp_core::U256::from_big_endian(&self.chain_id(latest_block).to_be_bytes()));
         }
 
         let tx = transaction
@@ -894,7 +877,7 @@ impl ApiServer {
         node_info!("eth_sendTransactionSync");
         // Subscribe to new best blocks.
         let receiver = self
-            .eth_rpc_client()?
+            .eth_rpc_client
             .block_notifier()
             .ok_or_else(|| {
                 Error::InternalError("Invalid receiver. Unable to wait for receipt".to_string())
@@ -910,13 +893,13 @@ impl ApiServer {
         hydrated_transactions: bool,
     ) -> Result<Option<Block>> {
         let Some(block) = self
-            .eth_rpc_client()?
+            .eth_rpc_client
             .block_by_number_or_tag(&ReviveBlockNumberOrTag::from(block_number).inner())
             .await?
         else {
             return Ok(None);
         };
-        let block = self.eth_rpc_client()?.evm_block(block, hydrated_transactions).await;
+        let block = self.eth_rpc_client.evm_block(block, hydrated_transactions).await;
         Ok(block)
     }
 
@@ -1002,7 +985,7 @@ impl ApiServer {
             transaction_order: "fifo".to_string(),
             environment: NodeEnvironment {
                 base_fee,
-                chain_id: self.chain_id_from_metadata(best_hash),
+                chain_id: self.chain_id(best_hash),
                 gas_limit,
                 gas_price: base_fee,
             },
@@ -1025,7 +1008,7 @@ impl ApiServer {
 
         Ok(AnvilMetadata {
             client_version: CLIENT_VERSION.to_string(),
-            chain_id: self.chain_id_from_metadata(best_hash),
+            chain_id: self.chain_id(best_hash),
             latest_block_hash: B256::from_slice(best_hash.as_ref()),
             latest_block_number,
             instance_id: self.instance_id,
@@ -1037,7 +1020,7 @@ impl ApiServer {
 
     async fn get_block_transaction_count_by_hash(&self, block_hash: B256) -> Result<Option<U256>> {
         let block_hash = H256::from_slice(block_hash.as_slice());
-        Ok(self.eth_rpc_client()?.receipts_count_per_block(&block_hash).await.map(U256::from))
+        Ok(self.eth_rpc_client.receipts_count_per_block(&block_hash).await.map(U256::from))
     }
 
     async fn get_block_transaction_count_by_number(
@@ -1050,7 +1033,7 @@ impl ApiServer {
             return Ok(None);
         };
 
-        Ok(self.eth_rpc_client()?.receipts_count_per_block(&hash).await.map(U256::from))
+        Ok(self.eth_rpc_client.receipts_count_per_block(&hash).await.map(U256::from))
     }
 
     async fn get_transaction_by_block_hash_and_index(
@@ -1059,7 +1042,7 @@ impl ApiServer {
         transaction_index: U256,
     ) -> Result<Option<TransactionInfo>> {
         let Some(receipt) = self
-            .eth_rpc_client()?
+            .eth_rpc_client
             .receipt_by_hash_and_index(
                 &H256::from_slice(block_hash.as_ref()),
                 transaction_index.try_into().map_err(|_| EthRpcError::ConversionError)?,
@@ -1070,7 +1053,7 @@ impl ApiServer {
         };
 
         let Some(signed_tx) =
-            self.eth_rpc_client()?.signed_tx_by_hash(&receipt.transaction_hash).await
+            self.eth_rpc_client.signed_tx_by_hash(&receipt.transaction_hash).await
         else {
             return Ok(None);
         };
@@ -1084,7 +1067,7 @@ impl ApiServer {
         transaction_index: U256,
     ) -> Result<Option<TransactionInfo>> {
         let Some(block) = self
-            .eth_rpc_client()?
+            .eth_rpc_client
             .block_by_number_or_tag(&ReviveBlockNumberOrTag::from(block).inner())
             .await?
         else {
@@ -1102,8 +1085,8 @@ impl ApiServer {
         transaction_hash: B256,
     ) -> Result<Option<TransactionInfo>> {
         let tx_hash = H256::from_slice(transaction_hash.as_ref());
-        let receipt = self.eth_rpc_client()?.receipt(&tx_hash).await;
-        let signed_tx = self.eth_rpc_client()?.signed_tx_by_hash(&tx_hash).await;
+        let receipt = self.eth_rpc_client.receipt(&tx_hash).await;
+        let signed_tx = self.eth_rpc_client.signed_tx_by_hash(&tx_hash).await;
         if let (Some(receipt), Some(signed_tx)) = (receipt, signed_tx) {
             return Ok(Some(TransactionInfo::new(&receipt, signed_tx)));
         }
@@ -1119,7 +1102,7 @@ impl ApiServer {
     ) -> Result<FeeHistoryResult> {
         let block_count: u32 = block_count.try_into().map_err(|_| EthRpcError::ConversionError)?;
         let result = self
-            .eth_rpc_client()?
+            .eth_rpc_client
             .fee_history(
                 block_count,
                 ReviveBlockNumberOrTag::from(newest_block).inner(),
@@ -1146,7 +1129,7 @@ impl ApiServer {
     }
 
     async fn get_logs(&self, filter: Filter) -> Result<FilterResults> {
-        let logs = self.eth_rpc_client()?.logs(Some(ReviveFilter::from(filter).into_inner())).await?;
+        let logs = self.eth_rpc_client.logs(Some(ReviveFilter::from(filter).into_inner())).await?;
         Ok(FilterResults::Logs(logs))
     }
 
@@ -1448,7 +1431,7 @@ impl ApiServer {
         let filter = EthFilter::PendingTransactions(PendingTransactionsFilter::new(
             BlockNotifications::new(self.new_block_notifications()?),
             self.tx_pool.clone(),
-            self.eth_rpc_client()?.clone(),
+            self.eth_rpc_client.clone(),
         ));
         Ok(self.filters.add_filter(filter).await)
     }
@@ -1458,7 +1441,7 @@ impl ApiServer {
         let eth_filter = EthFilter::Logs(
             LogsFilter::new(
                 BlockNotifications::new(self.new_block_notifications()?),
-                self.eth_rpc_client()?.clone(),
+                self.eth_rpc_client.clone(),
                 filter,
             )
             .await?,
@@ -1469,7 +1452,7 @@ impl ApiServer {
     async fn get_filter_logs(&self, id: &str) -> Result<Vec<Log>> {
         node_info!("eth_getFilterLogs");
         if let Some(filter) = self.filters.get_log_filter(id).await {
-            Ok(self.eth_rpc_client()?.logs(Some(filter)).await?)
+            Ok(self.eth_rpc_client.logs(Some(filter)).await?)
         } else {
             Ok(Vec::new())
         }
@@ -1523,14 +1506,14 @@ impl ApiServer {
                 let n = block_number.try_into().map_err(|_| {
                     Error::InvalidParams("Block number conversion failed".to_string())
                 })?;
-                Ok(self.eth_rpc_client()?.get_block_hash(n).await?)
+                Ok(self.eth_rpc_client.get_block_hash(n).await?)
             }
             BlockNumberOrTagOrHash::BlockTag(BlockTag::Finalized | BlockTag::Safe) => {
-                let block = self.eth_rpc_client()?.latest_finalized_block().await;
+                let block = self.eth_rpc_client.latest_finalized_block().await;
                 Ok(Some(block.hash()))
             }
             BlockNumberOrTagOrHash::BlockTag(_) => {
-                let block = self.eth_rpc_client()?.latest_block().await;
+                let block = self.eth_rpc_client.latest_block().await;
                 Ok(Some(block.hash()))
             }
         }
@@ -1716,7 +1699,7 @@ impl ApiServer {
     ) -> Result<GethTrace> {
         node_info!("debug_traceTransaction");
         let trace = self
-            .eth_rpc_client()?
+            .eth_rpc_client
             .trace_transaction(
                 H256::from_slice(tx_hash.as_ref()),
                 ReviveTracerType::from(geth_tracer_options).inner(),
@@ -1733,7 +1716,7 @@ impl ApiServer {
     ) -> Result<GethTrace> {
         node_info!("debug_traceCall");
         let hash = self.get_block_hash_for_tag(block_number).await?;
-        let runtime_api = self.eth_rpc_client()?.runtime_api(hash);
+        let runtime_api = self.eth_rpc_client.runtime_api(hash);
         let transaction = convert_to_generic_transaction(request.into_inner());
         let trace = runtime_api
             .trace_call(transaction, ReviveTracerType::from(geth_tracer_options).inner())
@@ -1744,7 +1727,7 @@ impl ApiServer {
     async fn trace_transaction(&self, tx_hash: B256) -> Result<Vec<LocalizedTransactionTrace>> {
         node_info!("trace_transaction");
         let trace = self
-            .eth_rpc_client()?
+            .eth_rpc_client
             .trace_transaction(
                 H256::from_slice(tx_hash.as_ref()),
                 TracerType::CallTracer(Some(CallTracerConfig::default())),
@@ -1764,7 +1747,7 @@ impl ApiServer {
             return Ok(vec![]);
         };
         let traces = self
-            .eth_rpc_client()?
+            .eth_rpc_client
             .trace_block_by_number(
                 ReviveBlockNumberOrTag::from(block_number).inner(),
                 TracerType::CallTracer(Some(CallTracerConfig::default())),
@@ -1824,7 +1807,7 @@ impl ApiServer {
     }
 
     fn new_block_notifications(&self) -> Result<tokio::sync::broadcast::Receiver<H256>> {
-        self.eth_rpc_client()?
+        self.eth_rpc_client
             .block_notifier()
             .map(|sender| sender.subscribe())
             .ok_or(Error::InternalError("Could not subscribe to new blocks. 😢".to_string()))
@@ -1894,9 +1877,10 @@ async fn create_online_client(
         )));
     };
 
-    // Fetch runtime version - this works without triggering lazy loading
     let Ok(runtime_version) = substrate_service.client.runtime_version_at(genesis_hash) else {
-        return Err(Error::InternalError("Runtime version not found".to_string()));
+        return Err(Error::InternalError(
+            "Runtime version not found for given genesis hash".to_string(),
+        ));
     };
 
     let subxt_runtime_version = SubxtRuntimeVersion {
@@ -1904,16 +1888,34 @@ async fn create_online_client(
         transaction_version: runtime_version.transaction_version,
     };
 
-    // In fork mode, use OnlineClient::from_rpc_client() which fetches metadata from RPC automatically
-    // In normal mode, use local client metadata to avoid unnecessary RPC calls
-    if substrate_service.backend.rpc().is_some() {
-        // Fork mode: Let OnlineClient fetch metadata from the remote RPC
-        // This avoids triggering the lazy loading backend during initialization
-        OnlineClient::<SrcChainConfig>::from_rpc_client(rpc_client)
+    // In fork mode, use RPC to fetch metadata directly to avoid lazy loading issues
+    // In normal mode, use the local runtime API
+    let subxt_metadata = if let Some(fork_url) = &substrate_service.fork_url {
+        // Fork mode: Create a temporary RPC client pointing to the remote fork URL
+        // to fetch metadata directly, avoiding lazy loading backend issues
+
+        // Convert HTTP(S) URLs to WebSocket URLs (ws/wss) as required by RpcClient
+        let ws_url = fork_url.replace("https://", "wss://").replace("http://", "ws://");
+
+        let remote_client = subxt::backend::rpc::RpcClient::from_url(&ws_url)
             .await
-            .map_err(|err| Error::InternalError(format!("Failed to initialize online client from RPC: {err}")))
+            .map_err(|err| {
+                Error::InternalError(format!(
+                    "Failed to connect to fork URL for metadata fetch: {err}"
+                ))
+            })?;
+
+        OnlineClient::<SrcChainConfig>::from_rpc_client(remote_client)
+            .await
+            .map_err(|err| {
+                Error::InternalError(format!(
+                    "Failed to create temporary client for metadata fetch in fork mode: {err}"
+                ))
+            })?
+            .metadata()
+            .clone()
     } else {
-        // Normal mode: Use local client runtime API (no lazy loading involved)
+        // Normal mode: use local runtime API
         let Ok(supported_metadata_versions) =
             substrate_service.client.runtime_api().metadata_versions(genesis_hash)
         else {
@@ -1928,77 +1930,30 @@ async fn create_online_client(
             .client
             .runtime_api()
             .metadata_at_version(genesis_hash, latest_metadata_version)
-            .map_err(|_| Error::InternalError("Failed to get runtime API".to_string()))?
+            .map_err(|_| {
+                Error::InternalError("Failed to get runtime API for genesis hash".to_string())
+            })?
             .ok_or_else(|| {
-                Error::InternalError(format!("Metadata not found for version {latest_metadata_version}"))
+                Error::InternalError(format!(
+                    "Metadata not found for version {latest_metadata_version} at genesis hash"
+                ))
             })?;
+        SubxtMetadata::decode(&mut (*opaque_metadata).as_slice())
+            .map_err(|_| Error::InternalError("Unable to decode metadata".to_string()))?
+    };
 
-        let subxt_metadata = SubxtMetadata::decode(&mut (*opaque_metadata).as_slice())
-            .map_err(|_| Error::InternalError("Unable to decode metadata".to_string()))?;
-
-        OnlineClient::<SrcChainConfig>::from_rpc_client_with(
-            genesis_hash,
-            subxt_runtime_version,
-            subxt_metadata,
-            rpc_client,
-        )
-        .map_err(|err| Error::InternalError(format!("Failed to initialize online client: {err}")))
-    }
+    OnlineClient::<SrcChainConfig>::from_rpc_client_with(
+        genesis_hash,
+        subxt_runtime_version,
+        subxt_metadata,
+        rpc_client,
+    )
+    .map_err(|err| {
+        Error::InternalError(format!("Failed to initialize the subxt online client: {err}"))
+    })
 }
 
 async fn create_revive_rpc_client(
-    api: OnlineClient<SrcChainConfig>,
-    rpc_client: RpcClient,
-    rpc: LegacyRpcMethods<SrcChainConfig>,
-    block_provider: SubxtBlockInfoProvider,
-    task_spawn_handle: SpawnTaskHandle,
-    keep_latest_n_blocks: Option<usize>,
-    in_fork_mode: bool,
-) -> Result<Option<EthRpcClient>> {
-    // In fork mode, try to create the EthRpcClient. If it fails (e.g., ReviveApi not available),
-    // return None to indicate limited mode without EVM RPC functionality.
-    // This is more robust than checking metadata, which may not include runtime API information.
-    if in_fork_mode {
-        // Try to create the client - if ReviveApi doesn't exist, this will fail
-        match create_revive_client_impl(
-            api.clone(),
-            rpc_client.clone(),
-            rpc.clone(),
-            block_provider.clone(),
-            task_spawn_handle.clone(),
-            keep_latest_n_blocks,
-        )
-        .await
-        {
-            Ok(client) => {
-                tracing::info!("ReviveApi available - EVM RPC functionality enabled");
-                return Ok(Some(client));
-            }
-            Err(e) => {
-                tracing::warn!(
-                    "ReviveApi not available in forked chain: {}. \
-                    Forking in limited mode - EVM RPC functionality will not be available.",
-                    e
-                );
-                return Ok(None);
-            }
-        }
-    }
-
-    // Normal mode: create the client and return errors if it fails
-    create_revive_client_impl(
-        api,
-        rpc_client,
-        rpc,
-        block_provider,
-        task_spawn_handle,
-        keep_latest_n_blocks,
-    )
-    .await
-    .map(Some)
-}
-
-async fn create_revive_client_impl(
     api: OnlineClient<SrcChainConfig>,
     rpc_client: RpcClient,
     rpc: LegacyRpcMethods<SrcChainConfig>,
@@ -2015,7 +1970,6 @@ async fn create_revive_client_impl(
         .await
         .map_err(|err| Error::ReviveRpc(EthRpcError::ClientError(ClientError::SqlxError(err))))?;
 
-    // Create ReceiptExtractor - this should succeed if ReviveApi is present
     let receipt_extractor = ReceiptExtractor::new_with_custom_address_recovery(
         api.clone(),
         None,

--- a/crates/anvil-polkadot/src/api_server/server.rs
+++ b/crates/anvil-polkadot/src/api_server/server.rs
@@ -37,7 +37,7 @@ use crate::{
 };
 use alloy_dyn_abi::TypedData;
 use alloy_eips::{BlockId, BlockNumberOrTag};
-use alloy_primitives::{hex, Address, B256, U64, U256};
+use alloy_primitives::{Address, B256, U64, U256};
 use alloy_rpc_types::{
     Filter, TransactionRequest,
     anvil::{Forking, Metadata as AnvilMetadata, MineOptions, NodeEnvironment, NodeInfo},
@@ -1894,58 +1894,26 @@ async fn create_online_client(
         )));
     };
 
-    // In fork mode, fetch metadata from remote RPC to avoid Tokio runtime conflicts
-    // Note: Remote metadata may not have ReviveApi, so we skip block processing in fork mode
-    if let Some(fork_url) = &substrate_service.fork_url {
-        use jsonrpsee::core::client::ClientT;
-        use subxt::ext::jsonrpsee::core::params::ArrayParams as RpcParams;
+    // Fetch runtime version - this works without triggering lazy loading
+    let Ok(runtime_version) = substrate_service.client.runtime_version_at(genesis_hash) else {
+        return Err(Error::InternalError("Runtime version not found".to_string()));
+    };
 
-        let http_client = jsonrpsee::http_client::HttpClientBuilder::default()
-            .max_request_size(u32::MAX)
-            .max_response_size(u32::MAX)
-            .request_timeout(std::time::Duration::from_secs(30))
-            .build(fork_url)
-            .map_err(|e| Error::InternalError(format!("Failed to build HTTP client: {e}")))?;
+    let subxt_runtime_version = SubxtRuntimeVersion {
+        spec_version: runtime_version.spec_version,
+        transaction_version: runtime_version.transaction_version,
+    };
 
-        let runtime_version: polkadot_sdk::sp_version::RuntimeVersion = http_client
-            .request("state_getRuntimeVersion", RpcParams::new())
+    // In fork mode, use OnlineClient::from_rpc_client() which fetches metadata from RPC automatically
+    // In normal mode, use local client metadata to avoid unnecessary RPC calls
+    if substrate_service.backend.rpc().is_some() {
+        // Fork mode: Let OnlineClient fetch metadata from the remote RPC
+        // This avoids triggering the lazy loading backend during initialization
+        OnlineClient::<SrcChainConfig>::from_rpc_client(rpc_client)
             .await
-            .map_err(|e| Error::InternalError(format!("Failed to fetch runtime version: {e}")))?;
-
-        let subxt_runtime_version = SubxtRuntimeVersion {
-            spec_version: runtime_version.spec_version,
-            transaction_version: runtime_version.transaction_version,
-        };
-
-        let metadata_hex: String = http_client
-            .request("state_getMetadata", RpcParams::new())
-            .await
-            .map_err(|e| Error::InternalError(format!("Failed to fetch metadata: {e}")))?;
-
-        let metadata_bytes = hex::decode(metadata_hex.trim_start_matches("0x"))
-            .map_err(|e| Error::InternalError(format!("Failed to decode metadata: {e}")))?;
-
-        let subxt_metadata = SubxtMetadata::decode(&mut &metadata_bytes[..])
-            .map_err(|e| Error::InternalError(format!("Failed to decode metadata: {e}")))?;
-
-        OnlineClient::<SrcChainConfig>::from_rpc_client_with(
-            genesis_hash,
-            subxt_runtime_version,
-            subxt_metadata,
-            rpc_client,
-        )
-        .map_err(|err| Error::InternalError(format!("Failed to initialize online client: {err}")))
+            .map_err(|err| Error::InternalError(format!("Failed to initialize online client from RPC: {err}")))
     } else {
-        // Normal mode: use local runtime metadata
-        let Ok(runtime_version) = substrate_service.client.runtime_version_at(genesis_hash) else {
-            return Err(Error::InternalError("Runtime version not found".to_string()));
-        };
-
-        let subxt_runtime_version = SubxtRuntimeVersion {
-            spec_version: runtime_version.spec_version,
-            transaction_version: runtime_version.transaction_version,
-        };
-
+        // Normal mode: Use local client runtime API (no lazy loading involved)
         let Ok(supported_metadata_versions) =
             substrate_service.client.runtime_api().metadata_versions(genesis_hash)
         else {
@@ -1961,7 +1929,9 @@ async fn create_online_client(
             .runtime_api()
             .metadata_at_version(genesis_hash, latest_metadata_version)
             .map_err(|_| Error::InternalError("Failed to get runtime API".to_string()))?
-            .ok_or_else(|| Error::InternalError(format!("Metadata not found for version {latest_metadata_version}")))?;
+            .ok_or_else(|| {
+                Error::InternalError(format!("Metadata not found for version {latest_metadata_version}"))
+            })?;
 
         let subxt_metadata = SubxtMetadata::decode(&mut (*opaque_metadata).as_slice())
             .map_err(|_| Error::InternalError("Unable to decode metadata".to_string()))?;
@@ -1985,22 +1955,57 @@ async fn create_revive_rpc_client(
     keep_latest_n_blocks: Option<usize>,
     in_fork_mode: bool,
 ) -> Result<Option<EthRpcClient>> {
-    // In fork mode, check if ReviveApi exists in metadata before proceeding
+    // In fork mode, try to create the EthRpcClient. If it fails (e.g., ReviveApi not available),
+    // return None to indicate limited mode without EVM RPC functionality.
+    // This is more robust than checking metadata, which may not include runtime API information.
     if in_fork_mode {
-        let metadata = api.metadata();
-        let has_revive_api = metadata.runtime_api_traits().any(|trait_metadata| {
-            trait_metadata.name() == "ReviveApi"
-        });
-
-        if !has_revive_api {
-            tracing::warn!(
-                "ReviveApi runtime trait not found in metadata. \
-                Forking in limited mode - EVM RPC functionality will not be available."
-            );
-            return Ok(None);
+        // Try to create the client - if ReviveApi doesn't exist, this will fail
+        match create_revive_client_impl(
+            api.clone(),
+            rpc_client.clone(),
+            rpc.clone(),
+            block_provider.clone(),
+            task_spawn_handle.clone(),
+            keep_latest_n_blocks,
+        )
+        .await
+        {
+            Ok(client) => {
+                tracing::info!("ReviveApi available - EVM RPC functionality enabled");
+                return Ok(Some(client));
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "ReviveApi not available in forked chain: {}. \
+                    Forking in limited mode - EVM RPC functionality will not be available.",
+                    e
+                );
+                return Ok(None);
+            }
         }
     }
 
+    // Normal mode: create the client and return errors if it fails
+    create_revive_client_impl(
+        api,
+        rpc_client,
+        rpc,
+        block_provider,
+        task_spawn_handle,
+        keep_latest_n_blocks,
+    )
+    .await
+    .map(Some)
+}
+
+async fn create_revive_client_impl(
+    api: OnlineClient<SrcChainConfig>,
+    rpc_client: RpcClient,
+    rpc: LegacyRpcMethods<SrcChainConfig>,
+    block_provider: SubxtBlockInfoProvider,
+    task_spawn_handle: SpawnTaskHandle,
+    keep_latest_n_blocks: Option<usize>,
+) -> Result<EthRpcClient> {
     let pool = SqlitePoolOptions::new()
         .max_connections(1)
         // see sqlite in-memory issue: https://github.com/launchbadge/sqlx/issues/2510
@@ -2031,23 +2036,20 @@ async fn create_revive_rpc_client(
             .await
             .map_err(Error::from)?;
 
-    // Skip block subscription task in fork mode since it requires ReviveApi
-    if !in_fork_mode {
-        // Capacity is chosen using random.org
-        eth_rpc_client.set_block_notifier(Some(tokio::sync::broadcast::channel::<H256>(50).0));
-        let eth_rpc_client_clone = eth_rpc_client.clone();
-        task_spawn_handle.spawn("block-subscription", "None", async move {
-            let eth_rpc_client = eth_rpc_client_clone;
-            let best_future =
-                eth_rpc_client.subscribe_and_cache_new_blocks(SubscriptionType::BestBlocks);
-            let finalized_future =
-                eth_rpc_client.subscribe_and_cache_new_blocks(SubscriptionType::FinalizedBlocks);
-            let res = tokio::try_join!(best_future, finalized_future).map(|_| ());
-            if let Err(err) = res {
-                panic!("Block subscription task failed: {err:?}")
-            }
-        });
-    }
+    // Capacity is chosen using random.org
+    eth_rpc_client.set_block_notifier(Some(tokio::sync::broadcast::channel::<H256>(50).0));
+    let eth_rpc_client_clone = eth_rpc_client.clone();
+    task_spawn_handle.spawn("block-subscription", "None", async move {
+        let eth_rpc_client = eth_rpc_client_clone;
+        let best_future =
+            eth_rpc_client.subscribe_and_cache_new_blocks(SubscriptionType::BestBlocks);
+        let finalized_future =
+            eth_rpc_client.subscribe_and_cache_new_blocks(SubscriptionType::FinalizedBlocks);
+        let res = tokio::try_join!(best_future, finalized_future).map(|_| ());
+        if let Err(err) = res {
+            panic!("Block subscription task failed: {err:?}")
+        }
+    });
 
-    Ok(Some(eth_rpc_client))
+    Ok(eth_rpc_client)
 }

--- a/crates/anvil-polkadot/src/api_server/server.rs
+++ b/crates/anvil-polkadot/src/api_server/server.rs
@@ -73,7 +73,7 @@ use polkadot_sdk::{
     },
     parachains_common::{AccountId, Hash, Nonce},
     polkadot_sdk_frame::runtime::types_common::OpaqueBlock,
-    sc_client_api::{Backend as BackendT, HeaderBackend},
+    sc_client_api::HeaderBackend,
     sc_service::{InPoolTransaction, SpawnTaskHandle, TransactionPool},
     sp_api::{Metadata as _, ProvideRuntimeApi},
     sp_blockchain::Info,
@@ -137,10 +137,6 @@ impl ApiServer {
         let api = create_online_client(&substrate_service, rpc_client.clone()).await?;
         let rpc = LegacyRpcMethods::<SrcChainConfig>::new(rpc_client.clone());
         let block_provider = SubxtBlockInfoProvider::new(api.clone(), rpc.clone()).await?;
-
-        // Check if we're in fork mode by checking if the backend has an RPC client
-        let is_fork_mode = substrate_service.backend.rpc().is_some();
-
         let eth_rpc_client = create_revive_rpc_client(
             api.clone(),
             rpc_client.clone(),
@@ -148,7 +144,6 @@ impl ApiServer {
             block_provider.clone(),
             substrate_service.spawn_handle.clone(),
             revive_rpc_block_limit,
-            is_fork_mode,
         )
         .await?;
 
@@ -1873,15 +1868,21 @@ async fn create_online_client(
     substrate_service: &Service,
     rpc_client: RpcClient,
 ) -> Result<OnlineClient<SrcChainConfig>> {
-    // Get genesis hash directly from blockchain info instead of querying by number
-    // This works correctly for both normal and fork modes
-    let genesis_hash = substrate_service.backend.blockchain().info().genesis_hash;
+    let genesis_block_number = substrate_service.genesis_block_number.try_into().map_err(|_| {
+        Error::InternalError(format!(
+            "Genesis block number {} is too large for u32 (max: {})",
+            substrate_service.genesis_block_number,
+            u32::MAX
+        ))
+    })?;
 
-    if genesis_hash == Default::default() {
-        return Err(Error::InternalError(
-            "Genesis hash not initialized in blockchain storage".to_string(),
-        ));
-    }
+    let Some(genesis_hash) = substrate_service.client.hash(genesis_block_number).ok().flatten()
+    else {
+        return Err(Error::InternalError(format!(
+            "Genesis hash not found for genesis block number {}",
+            substrate_service.genesis_block_number
+        )));
+    };
 
     let Ok(runtime_version) = substrate_service.client.runtime_version_at(genesis_hash) else {
         return Err(Error::InternalError(
@@ -1894,17 +1895,11 @@ async fn create_online_client(
         transaction_version: runtime_version.transaction_version,
     };
 
-    // In fork mode, genesis block may not have runtime code available.
-    // Try genesis first, then fall back to best block if that fails.
-    let supported_metadata_versions = substrate_service
-        .client
-        .runtime_api()
-        .metadata_versions(genesis_hash)
-        .or_else(|_| {
-            let best_hash = substrate_service.backend.blockchain().info().best_hash;
-            substrate_service.client.runtime_api().metadata_versions(best_hash)
-        })
-        .map_err(|e| Error::InternalError(format!("Unable to fetch metadata versions: {e}")))?;
+    let Ok(supported_metadata_versions) =
+        substrate_service.client.runtime_api().metadata_versions(genesis_hash)
+    else {
+        return Err(Error::InternalError("Unable to fetch metadata versions".to_string()));
+    };
 
     let Some(latest_metadata_version) = supported_metadata_versions.into_iter().max() else {
         return Err(Error::InternalError("No stable metadata versions supported".to_string()));
@@ -1943,7 +1938,6 @@ async fn create_revive_rpc_client(
     block_provider: SubxtBlockInfoProvider,
     task_spawn_handle: SpawnTaskHandle,
     keep_latest_n_blocks: Option<usize>,
-    is_fork_mode: bool,
 ) -> Result<EthRpcClient> {
     let pool = SqlitePoolOptions::new()
         .max_connections(1)
@@ -1976,26 +1970,18 @@ async fn create_revive_rpc_client(
 
     // Capacity is chosen using random.org
     eth_rpc_client.set_block_notifier(Some(tokio::sync::broadcast::channel::<H256>(50).0));
-
-    // In fork mode, we don't subscribe to new blocks from the remote chain because:
-    // 1. We're working with a snapshot at the fork checkpoint
-    // 2. Subscribing to blocks beyond the checkpoint causes ReceiptDataNotFound errors
-    // 3. New blocks after the fork are produced locally, not fetched from remote
-    if !is_fork_mode {
-        let eth_rpc_client_clone = eth_rpc_client.clone();
-        task_spawn_handle.spawn("block-subscription", "None", async move {
-            let eth_rpc_client = eth_rpc_client_clone;
-            let best_future =
-                eth_rpc_client.subscribe_and_cache_new_blocks(SubscriptionType::BestBlocks);
-            let finalized_future =
-                eth_rpc_client.subscribe_and_cache_new_blocks(SubscriptionType::FinalizedBlocks);
-            let res = tokio::try_join!(best_future, finalized_future).map(|_| ());
-            if let Err(err) = res {
-                // Log the error instead of panicking - this is expected during shutdown
-                warn!("Block subscription task ended: {err:?}");
-            }
-        });
-    }
+    let eth_rpc_client_clone = eth_rpc_client.clone();
+    task_spawn_handle.spawn("block-subscription", "None", async move {
+        let eth_rpc_client = eth_rpc_client_clone;
+        let best_future =
+            eth_rpc_client.subscribe_and_cache_new_blocks(SubscriptionType::BestBlocks);
+        let finalized_future =
+            eth_rpc_client.subscribe_and_cache_new_blocks(SubscriptionType::FinalizedBlocks);
+        let res = tokio::try_join!(best_future, finalized_future).map(|_| ());
+        if let Err(err) = res {
+            panic!("Block subscription task failed: {err:?}")
+        }
+    });
 
     Ok(eth_rpc_client)
 }

--- a/crates/anvil-polkadot/src/api_server/server.rs
+++ b/crates/anvil-polkadot/src/api_server/server.rs
@@ -37,7 +37,7 @@ use crate::{
 };
 use alloy_dyn_abi::TypedData;
 use alloy_eips::{BlockId, BlockNumberOrTag};
-use alloy_primitives::{Address, B256, U64, U256};
+use alloy_primitives::{hex, Address, B256, U64, U256};
 use alloy_rpc_types::{
     Filter, TransactionRequest,
     anvil::{Forking, Metadata as AnvilMetadata, MineOptions, NodeEnvironment, NodeInfo},
@@ -98,7 +98,7 @@ pub const CLIENT_VERSION: &str = concat!("anvil-polkadot/v", env!("CARGO_PKG_VER
 const TIMEOUT_DURATION: Duration = Duration::from_secs(30);
 
 pub struct ApiServer {
-    eth_rpc_client: EthRpcClient,
+    eth_rpc_client: Option<EthRpcClient>,
     req_receiver: mpsc::Receiver<ApiRequest>,
     backend: BackendWithOverlay,
     logging_manager: LoggingManager,
@@ -144,6 +144,7 @@ impl ApiServer {
             block_provider.clone(),
             substrate_service.spawn_handle.clone(),
             revive_rpc_block_limit,
+            substrate_service.fork_url.is_some(), // in_fork_mode
         )
         .await?;
 
@@ -176,6 +177,15 @@ impl ApiServer {
             instance_id: B256::random(),
             filters,
             hardcoded_chain_id: chain_id,
+        })
+    }
+
+    /// Returns a reference to the eth_rpc_client, or an error if it's not available (fork mode without ReviveApi)
+    fn eth_rpc_client(&self) -> Result<&EthRpcClient> {
+        self.eth_rpc_client.as_ref().ok_or_else(|| {
+            Error::InternalError(
+                "EVM RPC functionality not available. This chain was forked without ReviveApi support.".to_string()
+            )
         })
     }
 
@@ -481,7 +491,7 @@ impl ApiServer {
         }
 
         // Subscribe to new best blocks.
-        let receiver = self.eth_rpc_client.block_notifier().map(|sender| sender.subscribe());
+        let receiver = self.eth_rpc_client()?.block_notifier().map(|sender| sender.subscribe());
 
         let awaited_hash = self
             .mining_engine
@@ -522,7 +532,7 @@ impl ApiServer {
         node_info!("evm_mine");
 
         // Subscribe to new best blocks.
-        let receiver = self.eth_rpc_client.block_notifier().map(|sender| sender.subscribe());
+        let receiver = self.eth_rpc_client()?.block_notifier().map(|sender| sender.subscribe());
         let awaited_hash = self.mining_engine.evm_mine(mine.and_then(|p| p.params)).await?;
         self.wait_for_hash(receiver, awaited_hash).await?;
         Ok("0x0".to_string())
@@ -535,7 +545,7 @@ impl ApiServer {
         node_info!("evm_mine_detailed");
 
         // Subscribe to new best blocks.
-        let receiver = self.eth_rpc_client.block_notifier().map(|sender| sender.subscribe());
+        let receiver = self.eth_rpc_client()?.block_notifier().map(|sender| sender.subscribe());
 
         let (mined_blocks, awaited_hash) =
             self.mining_engine.do_evm_mine(mine.and_then(|p| p.params)).await?;
@@ -672,14 +682,14 @@ impl ApiServer {
 
     async fn transaction_receipt(&self, tx_hash: B256) -> Result<Option<ReceiptInfo>> {
         node_info!("eth_getTransactionReceipt");
-        Ok(self.eth_rpc_client.receipt(&(tx_hash.0.into())).await)
+        Ok(self.eth_rpc_client()?.receipt(&(tx_hash.0.into())).await)
     }
 
     async fn get_balance(&self, addr: Address, block: Option<BlockId>) -> Result<U256> {
         node_info!("eth_getBalance");
         let hash = self.get_block_hash_for_tag(block).await?;
 
-        let runtime_api = self.eth_rpc_client.runtime_api(hash);
+        let runtime_api = self.eth_rpc_client()?.runtime_api(hash);
         let balance = runtime_api.balance(ReviveAddress::from(addr).inner()).await?;
         Ok(AlloyU256::from(balance).inner())
     }
@@ -692,7 +702,7 @@ impl ApiServer {
     ) -> Result<B256> {
         node_info!("eth_getStorageAt");
         let hash = self.get_block_hash_for_tag(block).await?;
-        let runtime_api = self.eth_rpc_client.runtime_api(hash);
+        let runtime_api = self.eth_rpc_client()?.runtime_api(hash);
         let bytes: B256 = match runtime_api
             .get_storage(ReviveAddress::from(addr).inner(), slot.to_be_bytes())
             .await
@@ -711,7 +721,7 @@ impl ApiServer {
 
         let hash = self.get_block_hash_for_tag(block).await?;
         let code = self
-            .eth_rpc_client
+            .eth_rpc_client()?
             .runtime_api(hash)
             .code(ReviveAddress::from(address).inner())
             .await?;
@@ -725,11 +735,11 @@ impl ApiServer {
     ) -> Result<Option<Block>> {
         node_info!("eth_getBlockByHash");
         let Some(block) =
-            self.eth_rpc_client.block_by_hash(&H256::from_slice(block_hash.as_slice())).await?
+            self.eth_rpc_client()?.block_by_hash(&H256::from_slice(block_hash.as_slice())).await?
         else {
             return Ok(None);
         };
-        let block = self.eth_rpc_client.evm_block(block, hydrated_transactions).await;
+        let block = self.eth_rpc_client()?.evm_block(block, hydrated_transactions).await;
         Ok(block)
     }
 
@@ -741,7 +751,7 @@ impl ApiServer {
         node_info!("eth_estimateGas");
 
         let hash = self.get_block_hash_for_tag(block).await?;
-        let runtime_api = self.eth_rpc_client.runtime_api(hash);
+        let runtime_api = self.eth_rpc_client()?.runtime_api(hash);
         let dry_run = runtime_api
             .dry_run(
                 convert_to_generic_transaction(request.into_inner()),
@@ -760,7 +770,7 @@ impl ApiServer {
 
         let hash = self.get_block_hash_for_tag(block).await?;
 
-        let runtime_api = self.eth_rpc_client.runtime_api(hash);
+        let runtime_api = self.eth_rpc_client()?.runtime_api(hash);
         let dry_run = runtime_api
             .dry_run(
                 convert_to_generic_transaction(request.into_inner()),
@@ -776,7 +786,7 @@ impl ApiServer {
 
         let hash = self.latest_block();
 
-        let runtime_api = self.eth_rpc_client.runtime_api(hash);
+        let runtime_api = self.eth_rpc_client()?.runtime_api(hash);
         runtime_api.gas_price().await.map_err(Error::from)
     }
 
@@ -787,7 +797,7 @@ impl ApiServer {
     ) -> Result<sp_core::U256> {
         node_info!("eth_getTransactionCount");
         let hash = self.get_block_hash_for_tag(block).await?;
-        let runtime_api = self.eth_rpc_client.runtime_api(hash);
+        let runtime_api = self.eth_rpc_client()?.runtime_api(hash);
         let nonce = runtime_api.nonce(address).await?;
         Ok(nonce)
     }
@@ -795,7 +805,7 @@ impl ApiServer {
     async fn send_raw_transaction(&self, transaction: Bytes) -> Result<H256> {
         let hash = H256(keccak_256(&transaction.0));
         let call = subxt_client::tx().revive().eth_transact(transaction.0);
-        self.eth_rpc_client.submit(call).await?;
+        self.eth_rpc_client()?.submit(call).await?;
         Ok(hash)
     }
 
@@ -803,7 +813,7 @@ impl ApiServer {
         node_info!("eth_sendRawTransactionSync");
         // Subscribe to new best blocks.
         let receiver = self
-            .eth_rpc_client
+            .eth_rpc_client()?
             .block_notifier()
             .ok_or_else(|| {
                 Error::InternalError("Invalid receiver. Unable to wait for receipt".to_string())
@@ -884,7 +894,7 @@ impl ApiServer {
         node_info!("eth_sendTransactionSync");
         // Subscribe to new best blocks.
         let receiver = self
-            .eth_rpc_client
+            .eth_rpc_client()?
             .block_notifier()
             .ok_or_else(|| {
                 Error::InternalError("Invalid receiver. Unable to wait for receipt".to_string())
@@ -900,13 +910,13 @@ impl ApiServer {
         hydrated_transactions: bool,
     ) -> Result<Option<Block>> {
         let Some(block) = self
-            .eth_rpc_client
+            .eth_rpc_client()?
             .block_by_number_or_tag(&ReviveBlockNumberOrTag::from(block_number).inner())
             .await?
         else {
             return Ok(None);
         };
-        let block = self.eth_rpc_client.evm_block(block, hydrated_transactions).await;
+        let block = self.eth_rpc_client()?.evm_block(block, hydrated_transactions).await;
         Ok(block)
     }
 
@@ -1027,7 +1037,7 @@ impl ApiServer {
 
     async fn get_block_transaction_count_by_hash(&self, block_hash: B256) -> Result<Option<U256>> {
         let block_hash = H256::from_slice(block_hash.as_slice());
-        Ok(self.eth_rpc_client.receipts_count_per_block(&block_hash).await.map(U256::from))
+        Ok(self.eth_rpc_client()?.receipts_count_per_block(&block_hash).await.map(U256::from))
     }
 
     async fn get_block_transaction_count_by_number(
@@ -1040,7 +1050,7 @@ impl ApiServer {
             return Ok(None);
         };
 
-        Ok(self.eth_rpc_client.receipts_count_per_block(&hash).await.map(U256::from))
+        Ok(self.eth_rpc_client()?.receipts_count_per_block(&hash).await.map(U256::from))
     }
 
     async fn get_transaction_by_block_hash_and_index(
@@ -1049,7 +1059,7 @@ impl ApiServer {
         transaction_index: U256,
     ) -> Result<Option<TransactionInfo>> {
         let Some(receipt) = self
-            .eth_rpc_client
+            .eth_rpc_client()?
             .receipt_by_hash_and_index(
                 &H256::from_slice(block_hash.as_ref()),
                 transaction_index.try_into().map_err(|_| EthRpcError::ConversionError)?,
@@ -1060,7 +1070,7 @@ impl ApiServer {
         };
 
         let Some(signed_tx) =
-            self.eth_rpc_client.signed_tx_by_hash(&receipt.transaction_hash).await
+            self.eth_rpc_client()?.signed_tx_by_hash(&receipt.transaction_hash).await
         else {
             return Ok(None);
         };
@@ -1074,7 +1084,7 @@ impl ApiServer {
         transaction_index: U256,
     ) -> Result<Option<TransactionInfo>> {
         let Some(block) = self
-            .eth_rpc_client
+            .eth_rpc_client()?
             .block_by_number_or_tag(&ReviveBlockNumberOrTag::from(block).inner())
             .await?
         else {
@@ -1092,8 +1102,8 @@ impl ApiServer {
         transaction_hash: B256,
     ) -> Result<Option<TransactionInfo>> {
         let tx_hash = H256::from_slice(transaction_hash.as_ref());
-        let receipt = self.eth_rpc_client.receipt(&tx_hash).await;
-        let signed_tx = self.eth_rpc_client.signed_tx_by_hash(&tx_hash).await;
+        let receipt = self.eth_rpc_client()?.receipt(&tx_hash).await;
+        let signed_tx = self.eth_rpc_client()?.signed_tx_by_hash(&tx_hash).await;
         if let (Some(receipt), Some(signed_tx)) = (receipt, signed_tx) {
             return Ok(Some(TransactionInfo::new(&receipt, signed_tx)));
         }
@@ -1109,7 +1119,7 @@ impl ApiServer {
     ) -> Result<FeeHistoryResult> {
         let block_count: u32 = block_count.try_into().map_err(|_| EthRpcError::ConversionError)?;
         let result = self
-            .eth_rpc_client
+            .eth_rpc_client()?
             .fee_history(
                 block_count,
                 ReviveBlockNumberOrTag::from(newest_block).inner(),
@@ -1136,7 +1146,7 @@ impl ApiServer {
     }
 
     async fn get_logs(&self, filter: Filter) -> Result<FilterResults> {
-        let logs = self.eth_rpc_client.logs(Some(ReviveFilter::from(filter).into_inner())).await?;
+        let logs = self.eth_rpc_client()?.logs(Some(ReviveFilter::from(filter).into_inner())).await?;
         Ok(FilterResults::Logs(logs))
     }
 
@@ -1438,7 +1448,7 @@ impl ApiServer {
         let filter = EthFilter::PendingTransactions(PendingTransactionsFilter::new(
             BlockNotifications::new(self.new_block_notifications()?),
             self.tx_pool.clone(),
-            self.eth_rpc_client.clone(),
+            self.eth_rpc_client()?.clone(),
         ));
         Ok(self.filters.add_filter(filter).await)
     }
@@ -1448,7 +1458,7 @@ impl ApiServer {
         let eth_filter = EthFilter::Logs(
             LogsFilter::new(
                 BlockNotifications::new(self.new_block_notifications()?),
-                self.eth_rpc_client.clone(),
+                self.eth_rpc_client()?.clone(),
                 filter,
             )
             .await?,
@@ -1459,7 +1469,7 @@ impl ApiServer {
     async fn get_filter_logs(&self, id: &str) -> Result<Vec<Log>> {
         node_info!("eth_getFilterLogs");
         if let Some(filter) = self.filters.get_log_filter(id).await {
-            Ok(self.eth_rpc_client.logs(Some(filter)).await?)
+            Ok(self.eth_rpc_client()?.logs(Some(filter)).await?)
         } else {
             Ok(Vec::new())
         }
@@ -1513,14 +1523,14 @@ impl ApiServer {
                 let n = block_number.try_into().map_err(|_| {
                     Error::InvalidParams("Block number conversion failed".to_string())
                 })?;
-                Ok(self.eth_rpc_client.get_block_hash(n).await?)
+                Ok(self.eth_rpc_client()?.get_block_hash(n).await?)
             }
             BlockNumberOrTagOrHash::BlockTag(BlockTag::Finalized | BlockTag::Safe) => {
-                let block = self.eth_rpc_client.latest_finalized_block().await;
+                let block = self.eth_rpc_client()?.latest_finalized_block().await;
                 Ok(Some(block.hash()))
             }
             BlockNumberOrTagOrHash::BlockTag(_) => {
-                let block = self.eth_rpc_client.latest_block().await;
+                let block = self.eth_rpc_client()?.latest_block().await;
                 Ok(Some(block.hash()))
             }
         }
@@ -1706,7 +1716,7 @@ impl ApiServer {
     ) -> Result<GethTrace> {
         node_info!("debug_traceTransaction");
         let trace = self
-            .eth_rpc_client
+            .eth_rpc_client()?
             .trace_transaction(
                 H256::from_slice(tx_hash.as_ref()),
                 ReviveTracerType::from(geth_tracer_options).inner(),
@@ -1723,7 +1733,7 @@ impl ApiServer {
     ) -> Result<GethTrace> {
         node_info!("debug_traceCall");
         let hash = self.get_block_hash_for_tag(block_number).await?;
-        let runtime_api = self.eth_rpc_client.runtime_api(hash);
+        let runtime_api = self.eth_rpc_client()?.runtime_api(hash);
         let transaction = convert_to_generic_transaction(request.into_inner());
         let trace = runtime_api
             .trace_call(transaction, ReviveTracerType::from(geth_tracer_options).inner())
@@ -1734,7 +1744,7 @@ impl ApiServer {
     async fn trace_transaction(&self, tx_hash: B256) -> Result<Vec<LocalizedTransactionTrace>> {
         node_info!("trace_transaction");
         let trace = self
-            .eth_rpc_client
+            .eth_rpc_client()?
             .trace_transaction(
                 H256::from_slice(tx_hash.as_ref()),
                 TracerType::CallTracer(Some(CallTracerConfig::default())),
@@ -1754,7 +1764,7 @@ impl ApiServer {
             return Ok(vec![]);
         };
         let traces = self
-            .eth_rpc_client
+            .eth_rpc_client()?
             .trace_block_by_number(
                 ReviveBlockNumberOrTag::from(block_number).inner(),
                 TracerType::CallTracer(Some(CallTracerConfig::default())),
@@ -1814,7 +1824,7 @@ impl ApiServer {
     }
 
     fn new_block_notifications(&self) -> Result<tokio::sync::broadcast::Receiver<H256>> {
-        self.eth_rpc_client
+        self.eth_rpc_client()?
             .block_notifier()
             .map(|sender| sender.subscribe())
             .ok_or(Error::InternalError("Could not subscribe to new blocks. 😢".to_string()))
@@ -1884,51 +1894,86 @@ async fn create_online_client(
         )));
     };
 
-    let Ok(runtime_version) = substrate_service.client.runtime_version_at(genesis_hash) else {
-        return Err(Error::InternalError(
-            "Runtime version not found for given genesis hash".to_string(),
-        ));
-    };
+    // In fork mode, fetch metadata from remote RPC to avoid Tokio runtime conflicts
+    // Note: Remote metadata may not have ReviveApi, so we skip block processing in fork mode
+    if let Some(fork_url) = &substrate_service.fork_url {
+        use jsonrpsee::core::client::ClientT;
+        use subxt::ext::jsonrpsee::core::params::ArrayParams as RpcParams;
 
-    let subxt_runtime_version = SubxtRuntimeVersion {
-        spec_version: runtime_version.spec_version,
-        transaction_version: runtime_version.transaction_version,
-    };
+        let http_client = jsonrpsee::http_client::HttpClientBuilder::default()
+            .max_request_size(u32::MAX)
+            .max_response_size(u32::MAX)
+            .request_timeout(std::time::Duration::from_secs(30))
+            .build(fork_url)
+            .map_err(|e| Error::InternalError(format!("Failed to build HTTP client: {e}")))?;
 
-    let Ok(supported_metadata_versions) =
-        substrate_service.client.runtime_api().metadata_versions(genesis_hash)
-    else {
-        return Err(Error::InternalError("Unable to fetch metadata versions".to_string()));
-    };
+        let runtime_version: polkadot_sdk::sp_version::RuntimeVersion = http_client
+            .request("state_getRuntimeVersion", RpcParams::new())
+            .await
+            .map_err(|e| Error::InternalError(format!("Failed to fetch runtime version: {e}")))?;
 
-    let Some(latest_metadata_version) = supported_metadata_versions.into_iter().max() else {
-        return Err(Error::InternalError("No stable metadata versions supported".to_string()));
-    };
+        let subxt_runtime_version = SubxtRuntimeVersion {
+            spec_version: runtime_version.spec_version,
+            transaction_version: runtime_version.transaction_version,
+        };
 
-    let opaque_metadata = substrate_service
-        .client
-        .runtime_api()
-        .metadata_at_version(genesis_hash, latest_metadata_version)
-        .map_err(|_| {
-            Error::InternalError("Failed to get runtime API for genesis hash".to_string())
-        })?
-        .ok_or_else(|| {
-            Error::InternalError(format!(
-                "Metadata not found for version {latest_metadata_version} at genesis hash"
-            ))
-        })?;
-    let subxt_metadata = SubxtMetadata::decode(&mut (*opaque_metadata).as_slice())
-        .map_err(|_| Error::InternalError("Unable to decode metadata".to_string()))?;
+        let metadata_hex: String = http_client
+            .request("state_getMetadata", RpcParams::new())
+            .await
+            .map_err(|e| Error::InternalError(format!("Failed to fetch metadata: {e}")))?;
 
-    OnlineClient::<SrcChainConfig>::from_rpc_client_with(
-        genesis_hash,
-        subxt_runtime_version,
-        subxt_metadata,
-        rpc_client,
-    )
-    .map_err(|err| {
-        Error::InternalError(format!("Failed to initialize the subxt online client: {err}"))
-    })
+        let metadata_bytes = hex::decode(metadata_hex.trim_start_matches("0x"))
+            .map_err(|e| Error::InternalError(format!("Failed to decode metadata: {e}")))?;
+
+        let subxt_metadata = SubxtMetadata::decode(&mut &metadata_bytes[..])
+            .map_err(|e| Error::InternalError(format!("Failed to decode metadata: {e}")))?;
+
+        OnlineClient::<SrcChainConfig>::from_rpc_client_with(
+            genesis_hash,
+            subxt_runtime_version,
+            subxt_metadata,
+            rpc_client,
+        )
+        .map_err(|err| Error::InternalError(format!("Failed to initialize online client: {err}")))
+    } else {
+        // Normal mode: use local runtime metadata
+        let Ok(runtime_version) = substrate_service.client.runtime_version_at(genesis_hash) else {
+            return Err(Error::InternalError("Runtime version not found".to_string()));
+        };
+
+        let subxt_runtime_version = SubxtRuntimeVersion {
+            spec_version: runtime_version.spec_version,
+            transaction_version: runtime_version.transaction_version,
+        };
+
+        let Ok(supported_metadata_versions) =
+            substrate_service.client.runtime_api().metadata_versions(genesis_hash)
+        else {
+            return Err(Error::InternalError("Unable to fetch metadata versions".to_string()));
+        };
+
+        let Some(latest_metadata_version) = supported_metadata_versions.into_iter().max() else {
+            return Err(Error::InternalError("No stable metadata versions supported".to_string()));
+        };
+
+        let opaque_metadata = substrate_service
+            .client
+            .runtime_api()
+            .metadata_at_version(genesis_hash, latest_metadata_version)
+            .map_err(|_| Error::InternalError("Failed to get runtime API".to_string()))?
+            .ok_or_else(|| Error::InternalError(format!("Metadata not found for version {latest_metadata_version}")))?;
+
+        let subxt_metadata = SubxtMetadata::decode(&mut (*opaque_metadata).as_slice())
+            .map_err(|_| Error::InternalError("Unable to decode metadata".to_string()))?;
+
+        OnlineClient::<SrcChainConfig>::from_rpc_client_with(
+            genesis_hash,
+            subxt_runtime_version,
+            subxt_metadata,
+            rpc_client,
+        )
+        .map_err(|err| Error::InternalError(format!("Failed to initialize online client: {err}")))
+    }
 }
 
 async fn create_revive_rpc_client(
@@ -1938,7 +1983,24 @@ async fn create_revive_rpc_client(
     block_provider: SubxtBlockInfoProvider,
     task_spawn_handle: SpawnTaskHandle,
     keep_latest_n_blocks: Option<usize>,
-) -> Result<EthRpcClient> {
+    in_fork_mode: bool,
+) -> Result<Option<EthRpcClient>> {
+    // In fork mode, check if ReviveApi exists in metadata before proceeding
+    if in_fork_mode {
+        let metadata = api.metadata();
+        let has_revive_api = metadata.runtime_api_traits().any(|trait_metadata| {
+            trait_metadata.name() == "ReviveApi"
+        });
+
+        if !has_revive_api {
+            tracing::warn!(
+                "ReviveApi runtime trait not found in metadata. \
+                Forking in limited mode - EVM RPC functionality will not be available."
+            );
+            return Ok(None);
+        }
+    }
+
     let pool = SqlitePoolOptions::new()
         .max_connections(1)
         // see sqlite in-memory issue: https://github.com/launchbadge/sqlx/issues/2510
@@ -1948,6 +2010,7 @@ async fn create_revive_rpc_client(
         .await
         .map_err(|err| Error::ReviveRpc(EthRpcError::ClientError(ClientError::SqlxError(err))))?;
 
+    // Create ReceiptExtractor - this should succeed if ReviveApi is present
     let receipt_extractor = ReceiptExtractor::new_with_custom_address_recovery(
         api.clone(),
         None,
@@ -1968,20 +2031,23 @@ async fn create_revive_rpc_client(
             .await
             .map_err(Error::from)?;
 
-    // Capacity is chosen using random.org
-    eth_rpc_client.set_block_notifier(Some(tokio::sync::broadcast::channel::<H256>(50).0));
-    let eth_rpc_client_clone = eth_rpc_client.clone();
-    task_spawn_handle.spawn("block-subscription", "None", async move {
-        let eth_rpc_client = eth_rpc_client_clone;
-        let best_future =
-            eth_rpc_client.subscribe_and_cache_new_blocks(SubscriptionType::BestBlocks);
-        let finalized_future =
-            eth_rpc_client.subscribe_and_cache_new_blocks(SubscriptionType::FinalizedBlocks);
-        let res = tokio::try_join!(best_future, finalized_future).map(|_| ());
-        if let Err(err) = res {
-            panic!("Block subscription task failed: {err:?}")
-        }
-    });
+    // Skip block subscription task in fork mode since it requires ReviveApi
+    if !in_fork_mode {
+        // Capacity is chosen using random.org
+        eth_rpc_client.set_block_notifier(Some(tokio::sync::broadcast::channel::<H256>(50).0));
+        let eth_rpc_client_clone = eth_rpc_client.clone();
+        task_spawn_handle.spawn("block-subscription", "None", async move {
+            let eth_rpc_client = eth_rpc_client_clone;
+            let best_future =
+                eth_rpc_client.subscribe_and_cache_new_blocks(SubscriptionType::BestBlocks);
+            let finalized_future =
+                eth_rpc_client.subscribe_and_cache_new_blocks(SubscriptionType::FinalizedBlocks);
+            let res = tokio::try_join!(best_future, finalized_future).map(|_| ());
+            if let Err(err) = res {
+                panic!("Block subscription task failed: {err:?}")
+            }
+        });
+    }
 
-    Ok(eth_rpc_client)
+    Ok(Some(eth_rpc_client))
 }

--- a/crates/anvil-polkadot/src/substrate_node/lazy_loading/backend/mod.rs
+++ b/crates/anvil-polkadot/src/substrate_node/lazy_loading/backend/mod.rs
@@ -56,7 +56,7 @@ impl<Block: BlockT + DeserializeOwned> Backend<Block> {
     }
 
     #[inline]
-    fn fork_checkpoint(&self) -> Option<&Block::Header> {
+    pub fn fork_checkpoint(&self) -> Option<&Block::Header> {
         self.fork_config.as_ref().map(|(_, checkpoint)| checkpoint)
     }
 }

--- a/crates/anvil-polkadot/src/substrate_node/lazy_loading/rpc_client.rs
+++ b/crates/anvil-polkadot/src/substrate_node/lazy_loading/rpc_client.rs
@@ -125,9 +125,8 @@ impl<Block: BlockT + DeserializeOwned> Rpc<Block> {
 
         // Use the global RPC runtime to avoid Tokio context conflicts
         // The runtime is spawned on a separate thread to completely isolate from the main runtime
-        let (tx, rx) = std::sync::mpsc::channel();
         std::thread::spawn(move || {
-            let result = get_rpc_runtime().block_on(async move {
+            get_rpc_runtime().block_on(async move {
                 let start_req = std::time::Instant::now();
                 tracing::debug!(
                     target: super::LAZY_LOADING_LOG_TARGET,
@@ -151,11 +150,10 @@ impl<Block: BlockT + DeserializeOwned> Rpc<Block> {
                 );
 
                 result
-            });
-            let _ = tx.send(result);
-        });
-
-        rx.recv().expect("RPC thread terminated unexpectedly")
+            })
+        })
+        .join()
+        .expect("RPC thread panicked")
     }
 }
 

--- a/crates/anvil-polkadot/src/substrate_node/lazy_loading/rpc_client.rs
+++ b/crates/anvil-polkadot/src/substrate_node/lazy_loading/rpc_client.rs
@@ -124,7 +124,7 @@ impl<Block: BlockT + DeserializeOwned> Rpc<Block> {
                 );
 
                 // Explicit request delay, to avoid getting 429 errors
-                let _ = tokio::time::sleep(delay_between_requests).await;
+                tokio::time::sleep(delay_between_requests).await;
 
                 // Execute the request
                 let result = future.await;

--- a/crates/anvil-polkadot/src/substrate_node/lazy_loading/rpc_client.rs
+++ b/crates/anvil-polkadot/src/substrate_node/lazy_loading/rpc_client.rs
@@ -13,12 +13,21 @@ use serde::de::DeserializeOwned;
 use std::{
     marker::PhantomData,
     sync::{
-        Arc,
+        Arc, OnceLock,
         atomic::{AtomicU64, Ordering},
     },
     time::Duration,
 };
-use tokio::runtime::Handle;
+use tokio::runtime::Runtime;
+
+// Global runtime for RPC calls that persists for the entire process lifetime
+// This avoids issues with dropping runtimes in async contexts
+fn get_rpc_runtime() -> &'static Runtime {
+    static RPC_RUNTIME: OnceLock<Runtime> = OnceLock::new();
+    RPC_RUNTIME.get_or_init(|| {
+        Runtime::new().expect("Failed to create RPC runtime")
+    })
+}
 
 type BlockNumber = u64;
 
@@ -106,16 +115,19 @@ impl<Block: BlockT + DeserializeOwned> Rpc<Block> {
 
     fn block_on<F, T, E>(&self, future: F) -> Result<T, E>
     where
-        F: std::future::Future<Output = Result<T, E>> + Send,
-        T: Send,
-        E: Send,
+        F: std::future::Future<Output = Result<T, E>> + Send + 'static,
+        T: Send + 'static,
+        E: Send + 'static,
     {
         let id = self.counter.fetch_add(1, Ordering::SeqCst);
         let start = std::time::Instant::now();
         let delay_between_requests = Duration::from_millis(self.delay_between_requests_ms.into());
 
-        tokio::task::block_in_place(move || {
-            Handle::current().block_on(async move {
+        // Use the global RPC runtime to avoid Tokio context conflicts
+        // The runtime is spawned on a separate thread to completely isolate from the main runtime
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let result = get_rpc_runtime().block_on(async move {
                 let start_req = std::time::Instant::now();
                 tracing::debug!(
                     target: super::LAZY_LOADING_LOG_TARGET,
@@ -139,8 +151,11 @@ impl<Block: BlockT + DeserializeOwned> Rpc<Block> {
                 );
 
                 result
-            })
-        })
+            });
+            let _ = tx.send(result);
+        });
+
+        rx.recv().expect("RPC thread terminated unexpectedly")
     }
 }
 
@@ -447,6 +462,7 @@ mod tests {
         let (addr, handle) = start_mock_server_ok().await;
         let url = format!("http://{addr}");
         let client = HttpClientBuilder::default().build(&url).unwrap();
+
         (Rpc::<BlockType>::new(client, 0), handle)
     }
 

--- a/crates/anvil-polkadot/src/substrate_node/lazy_loading/rpc_client.rs
+++ b/crates/anvil-polkadot/src/substrate_node/lazy_loading/rpc_client.rs
@@ -13,21 +13,12 @@ use serde::de::DeserializeOwned;
 use std::{
     marker::PhantomData,
     sync::{
-        Arc, OnceLock,
+        Arc,
         atomic::{AtomicU64, Ordering},
     },
     time::Duration,
 };
-use tokio::runtime::Runtime;
-
-// Global runtime for RPC calls that persists for the entire process lifetime
-// This avoids issues with dropping runtimes in async contexts
-fn get_rpc_runtime() -> &'static Runtime {
-    static RPC_RUNTIME: OnceLock<Runtime> = OnceLock::new();
-    RPC_RUNTIME.get_or_init(|| {
-        Runtime::new().expect("Failed to create RPC runtime")
-    })
-}
+use tokio::runtime::Handle;
 
 type BlockNumber = u64;
 
@@ -115,18 +106,16 @@ impl<Block: BlockT + DeserializeOwned> Rpc<Block> {
 
     fn block_on<F, T, E>(&self, future: F) -> Result<T, E>
     where
-        F: std::future::Future<Output = Result<T, E>> + Send + 'static,
-        T: Send + 'static,
-        E: Send + 'static,
+        F: std::future::Future<Output = Result<T, E>> + Send,
+        T: Send,
+        E: Send,
     {
         let id = self.counter.fetch_add(1, Ordering::SeqCst);
         let start = std::time::Instant::now();
         let delay_between_requests = Duration::from_millis(self.delay_between_requests_ms.into());
 
-        // Use the global RPC runtime to avoid Tokio context conflicts
-        // The runtime is spawned on a separate thread to completely isolate from the main runtime
-        std::thread::spawn(move || {
-            get_rpc_runtime().block_on(async move {
+        tokio::task::block_in_place(move || {
+            Handle::current().block_on(async move {
                 let start_req = std::time::Instant::now();
                 tracing::debug!(
                     target: super::LAZY_LOADING_LOG_TARGET,
@@ -135,7 +124,7 @@ impl<Block: BlockT + DeserializeOwned> Rpc<Block> {
                 );
 
                 // Explicit request delay, to avoid getting 429 errors
-                tokio::time::sleep(delay_between_requests).await;
+                let _ = tokio::time::sleep(delay_between_requests).await;
 
                 // Execute the request
                 let result = future.await;
@@ -152,8 +141,6 @@ impl<Block: BlockT + DeserializeOwned> Rpc<Block> {
                 result
             })
         })
-        .join()
-        .expect("RPC thread panicked")
     }
 }
 
@@ -460,7 +447,6 @@ mod tests {
         let (addr, handle) = start_mock_server_ok().await;
         let url = format!("http://{addr}");
         let client = HttpClientBuilder::default().build(&url).unwrap();
-
         (Rpc::<BlockType>::new(client, 0), handle)
     }
 

--- a/crates/anvil-polkadot/src/substrate_node/service/mod.rs
+++ b/crates/anvil-polkadot/src/substrate_node/service/mod.rs
@@ -56,6 +56,9 @@ pub struct Service {
     pub storage_overrides: Arc<Mutex<StorageOverrides>>,
     pub genesis_block_number: u64,
     pub fork_url: Option<String>,
+    /// Hash of the checkpoint block when in fork mode. Used to avoid lazy loading issues
+    /// when fetching metadata at startup.
+    pub checkpoint_hash: Option<Hash>,
 }
 
 type CreateInherentDataProviders = Box<
@@ -301,13 +304,14 @@ pub fn new(
         Service {
             spawn_handle: task_manager.spawn_handle(),
             client,
-            backend,
+            backend: backend.clone(),
             tx_pool: transaction_pool,
             rpc_handlers,
             mining_engine,
             storage_overrides,
             genesis_block_number: anvil_config.get_genesis_number(),
             fork_url: anvil_config.eth_rpc_url.clone(),
+            checkpoint_hash: backend.fork_checkpoint().map(|h| h.hash()),
         },
         task_manager,
     ))

--- a/crates/anvil-polkadot/src/substrate_node/service/mod.rs
+++ b/crates/anvil-polkadot/src/substrate_node/service/mod.rs
@@ -55,6 +55,7 @@ pub struct Service {
     pub mining_engine: Arc<MiningEngine>,
     pub storage_overrides: Arc<Mutex<StorageOverrides>>,
     pub genesis_block_number: u64,
+    pub fork_url: Option<String>,
 }
 
 type CreateInherentDataProviders = Box<
@@ -306,6 +307,7 @@ pub fn new(
             mining_engine,
             storage_overrides,
             genesis_block_number: anvil_config.get_genesis_number(),
+            fork_url: anvil_config.eth_rpc_url.clone(),
         },
         task_manager,
     ))

--- a/crates/anvil-polkadot/src/substrate_node/service/mod.rs
+++ b/crates/anvil-polkadot/src/substrate_node/service/mod.rs
@@ -94,8 +94,6 @@ fn create_manual_seal_inherent_data_providers(
             Err(e) => return futures::future::ready(Err(Box::new(e))),
         };
 
-        println!("nex block num {}", next_block_number);
-
         let id = client
             .runtime_api()
             .parachain_id(current_para_head.hash())
@@ -138,6 +136,36 @@ fn create_manual_seal_inherent_data_providers(
         // This helps with allowing greater block production velocity per relay chain slot.
         backend.inject_relay_slot_info(current_para_head.hash(), (slot_in_state, 0));
 
+        // Read the DMQ MQC head from parachain storage to avoid "DMQ head mismatch" errors
+        // The storage key is: twox_128("ParachainSystem") + twox_128("LastDmqMqcHead")
+        let pallet_prefix = polkadot_sdk::sp_core::twox_128(b"ParachainSystem");
+        let storage_prefix = polkadot_sdk::sp_core::twox_128(b"LastDmqMqcHead");
+        let mut dmq_storage_key = Vec::new();
+        dmq_storage_key.extend_from_slice(&pallet_prefix);
+        dmq_storage_key.extend_from_slice(&storage_prefix);
+
+        // Read the MessageQueueChain from storage and extract its head hash
+        use polkadot_sdk::sc_client_api::StorageProvider;
+        let dmq_mqc_head = client
+            .storage(
+                current_para_head.hash(),
+                &polkadot_sdk::sc_client_api::StorageKey(dmq_storage_key),
+            )
+            .ok()
+            .flatten()
+            .and_then(|encoded_data| {
+                // MessageQueueChain is just a wrapper around a Hash, decode it
+                // The MessageQueueChain stores the head as the last 32 bytes
+                if encoded_data.0.len() >= 32 {
+                    let mut hash_bytes = [0u8; 32];
+                    hash_bytes.copy_from_slice(&encoded_data.0[encoded_data.0.len() - 32..]);
+                    Some(polkadot_sdk::cumulus_primitives_core::relay_chain::Hash::from(hash_bytes))
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_default(); // Use default (zeros) if we can't read it
+
         let mocked_parachain = MockValidationDataInherentDataProvider::<()> {
             current_para_block: next_block_number,
             para_id,
@@ -148,6 +176,10 @@ fn create_manual_seal_inherent_data_providers(
             relay_offset: last_rc_block_number + 1,
             current_para_block_head,
             additional_key_values: Some(additional_key_values),
+            xcm_config: polkadot_sdk::cumulus_client_parachain_inherent::MockXcmConfig {
+                starting_dmq_mqc_head: dmq_mqc_head,
+                starting_hrmp_mqc_heads: Default::default(),
+            },
             ..Default::default()
         };
 

--- a/crates/anvil-polkadot/tests/it/forking.rs
+++ b/crates/anvil-polkadot/tests/it/forking.rs
@@ -12,7 +12,7 @@ use anvil_polkadot::{
     api_server::revive_conversions::ReviveAddress,
     config::{AnvilNodeConfig, ForkChoice, SubstrateNodeConfig},
 };
-use polkadot_sdk::pallet_revive::evm::Account;
+use polkadot_sdk::{pallet_revive::evm::Account, sp_blockchain::HeaderBackend, sp_core::H256};
 
 /// Tests that forking preserves state from the source chain and allows local modifications
 #[tokio::test(flavor = "multi_thread")]
@@ -411,6 +411,64 @@ async fn test_fork_from_negative_block_number() {
     // Step 7: Verify fork advanced to block 4
     let fork_new_block = fork_node.best_block_number().await;
     assert_eq!(fork_new_block, 4, "Forked node should be at block 4");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_from_westend_assethub() {
+    // Step 1: Set a specific block height to fork from
+    let fork_block_number = 13268000;
+    let assethub_rpc_url = "https://westend-asset-hub-rpc.polkadot.io".to_string();
+
+    // Step 2: Create a forked node from Westend AssetHub at the specific block
+    let fork_config = AnvilNodeConfig::test_config()
+        .with_port(0)
+        .with_eth_rpc_url(Some(assethub_rpc_url.clone()))
+        .with_fork_block_number(Some(fork_block_number as u64));
+
+    let fork_substrate_config = SubstrateNodeConfig::new(&fork_config);
+
+    // Step 3: Verify the forked node can start successfully
+    let mut fork_node = match TestNode::new(fork_config.clone(), fork_substrate_config).await {
+        Ok(node) => node,
+        Err(e) => {
+            panic!("Failed to start forked node from AssetHub: {e}");
+        }
+    };
+
+    // Step 4: Get the initial block number from the fork
+    let fork_initial_block = fork_node.best_block_number().await;
+
+    // Verify the fork started at the expected block number
+    assert_eq!(
+        fork_initial_block, fork_block_number,
+        "Fork should start from block {fork_block_number}"
+    );
+
+    // Step 5: Query AssetHub to get expected block hash
+    let rpc_client = fork_node
+        .service
+        .backend
+        .rpc()
+        .expect("Fork mode should have RPC client configured");
+
+    let expected_block_hash: H256 = rpc_client
+        .block_hash(Some(fork_block_number))
+        .expect("Failed to get block hash from AssetHub RPC")
+        .expect("Block not found on AssetHub");
+
+    // Step 6: Get the Substrate block hash from the forked node's client
+    let fork_substrate_hash = fork_node
+        .service
+        .client
+        .hash(fork_initial_block)
+        .expect("Failed to get block hash")
+        .expect("Block should exist");
+
+    // Step 7: Verify the fork's Substrate block hash matches the expected hash from AssetHub
+    assert_eq!(
+        fork_substrate_hash, expected_block_hash,
+        "Fork Substrate block hash should match AssetHub block hash at block {fork_block_number}"
+    );
 }
 
 /// Tests that forking preserves contract state from source chain and that multiple contract


### PR DESCRIPTION
# Description

  Fixes several panics that occurred when forking real Asset Hub (westend) using:

```cargo run  -p anvil-polkadot -- --fork-url https://westend-asset-hub-rpc.polkadot.io```

  - Uses the checkpoint block hash directly when creating the OnlineClient in fork mode, instead of trying to derive it from the genesis block number
  - Reads the DMQ MQC head from parachain storage (ParachainSystem::LastDmqMqcHead) to properly initialize the MockValidationDataInherentDataProvider, avoiding "DMQ head mismatch" errors during block production
  - Adds first integration test for forking from Westend Asset Hub and check the previous changes